### PR TITLE
Strings can send properly when they contain non-terminating '\0' characters.

### DIFF
--- a/Sharing/Src/Source/Common/Private/NetworkInMessageImpl.cpp
+++ b/Sharing/Src/Source/Common/Private/NetworkInMessageImpl.cpp
@@ -68,9 +68,15 @@ double NetworkInMessageImpl::ReadDouble()
 
 XStringPtr NetworkInMessageImpl::ReadString()
 {
-	RakNet::RakString value;
-	XTVERIFY(m_stream.Read(value));
-	return new XString(value.C_String());
+	uint32 dwSize = 0;
+	m_stream.Read(dwSize);
+	if ( dwSize > 0 )
+	{
+		std::string s(dwSize, '\0');
+		XTVERIFY(m_stream.ReadAlignedBytes(const_cast<unsigned char *>(reinterpret_cast<const unsigned char *>(s.data())), dwSize));
+		return new XString(s);
+	}
+	return new XString();
 }
 
 
@@ -106,9 +112,15 @@ uint64 NetworkInMessageImpl::ReadUInt64()
 
 std::string NetworkInMessageImpl::ReadStdString()
 {
-	RakNet::RakString value;
-	XTVERIFY(m_stream.Read(value));
-	return value.C_String();
+	uint32 dwSize = 0;
+	m_stream.Read(dwSize);
+	if (dwSize > 0)
+	{
+		std::string s(dwSize, '\0');
+		XTVERIFY(m_stream.ReadAlignedBytes(const_cast<unsigned char *>(reinterpret_cast<const unsigned char *>(s.data())), dwSize));
+		return s;
+	}
+	return std::string();
 }
 
 

--- a/Sharing/Src/Source/Common/Private/NetworkOutMessageImpl.cpp
+++ b/Sharing/Src/Source/Common/Private/NetworkOutMessageImpl.cpp
@@ -60,11 +60,12 @@ void NetworkOutMessageImpl::Write(const XStringPtr& value)
 {
 	if (value)
 	{
-		m_stream.Write(RakNet::RakString(value->GetString().c_str()));
+		m_stream.Write((uint32)value->GetString().size());
+		m_stream.WriteAlignedBytes((const unsigned char *)value->GetString().data(), (uint32)value->GetString().size());
 	}
 	else
 	{
-		m_stream.Write(RakNet::RakString(""));
+		m_stream.Write(uint32(0));
 	}
 }
 
@@ -107,7 +108,8 @@ uint32 NetworkOutMessageImpl::GetSize() const
 
 void NetworkOutMessageImpl::Write(const std::string& value)
 {
-	m_stream.Write(RakNet::RakString(value.c_str()));
+	m_stream.Write((uint32)value.size());
+	m_stream.WriteAlignedBytes((const unsigned char *)value.data(), (uint32)value.size());
 }
 
 


### PR DESCRIPTION
Strings are now sent as a 32-bit size and then a raw data buffer using WriteAlignedBytes rather than as a RakNet::RakString. This allows for strings with non-terminating '\0' characters to be properly sent, which is especially useful for wrapping raw binary data into std::string for sending to other clients.

IMPORTANT: This change is not backwards compatible, and so all clients and server must be built with this change. Old servers/clients will crash if receiving data from new clients/server.