### PR TITLE
Fix a few bugs in SpatialInput libraries and sample apps

### DIFF
--- a/SpatialInput/Libs/Gltf/Gltf.vcxproj
+++ b/SpatialInput/Libs/Gltf/Gltf.vcxproj
@@ -101,6 +101,12 @@
       <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpplatest</LanguageStandard>
       <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</RuntimeTypeInfo>
       <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpplatest</LanguageStandard>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsManaged>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsManaged>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsManaged>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsManaged>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsManaged>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsManaged>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/SpatialInput/Libs/Neso/Neso.vcxproj
+++ b/SpatialInput/Libs/Neso/Neso.vcxproj
@@ -89,6 +89,12 @@
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">/await %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">/await %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/await %(AdditionalOptions)</AdditionalOptions>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsManaged>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsManaged>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsManaged>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsManaged>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsManaged>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsManaged>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/SpatialInput/Libs/Pbr/Pbr.vcxproj
+++ b/SpatialInput/Libs/Pbr/Pbr.vcxproj
@@ -99,6 +99,9 @@
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsManaged>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsManaged>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsManaged>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
@@ -106,6 +109,9 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsManaged>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsManaged>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsManaged>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/SpatialInput/Libs/SpatialInputUtilities/SpatialInputUtilities.vcxproj
+++ b/SpatialInput/Libs/SpatialInputUtilities/SpatialInputUtilities.vcxproj
@@ -126,6 +126,12 @@
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">$(ProjectDir);$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(ProjectDir);$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">$(ProjectDir);$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsManaged>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsManaged>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsManaged>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsManaged>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsManaged>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsManaged>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/SpatialInput/Samples/DemoRoom/AppView.cpp
+++ b/SpatialInput/Samples/DemoRoom/AppView.cpp
@@ -16,9 +16,9 @@ using namespace winrt::Windows::Graphics::Holographic;
 using namespace winrt::Windows::UI::Core;
 
 // The main function bootstraps into the IFrameworkView.
-[Platform::MTAThread]
 int __stdcall wWinMain(HINSTANCE, HINSTANCE, PWSTR, int)
 {
+    winrt::init_apartment();
     CoreApplication::Run(AppViewSource());
     return 0;
 }

--- a/SpatialInput/Samples/DemoRoom/DemoRoom.vcxproj
+++ b/SpatialInput/Samples/DemoRoom/DemoRoom.vcxproj
@@ -74,6 +74,7 @@
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories); $(VCInstallDir)\lib\store; $(VCInstallDir)\lib</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>mincore.lib;kernel32.lib;ole32.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <OutputFile>$(OutDir)$(ProjectName)$(TargetExt)</OutputFile>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
     </Link>
     <ClCompile>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -84,6 +85,8 @@
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <CompileAsManaged>false</CompileAsManaged>
+      <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -92,6 +95,7 @@
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories); $(VCInstallDir)\lib\store; $(VCInstallDir)\lib</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>mincore.lib;kernel32.lib;ole32.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <OutputFile>$(OutDir)$(ProjectName)$(TargetExt)</OutputFile>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
     </Link>
     <ClCompile>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -102,6 +106,8 @@
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <CompileAsManaged>false</CompileAsManaged>
+      <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -110,6 +116,7 @@
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories); $(VCInstallDir)\lib\store\amd64; $(VCInstallDir)\lib\amd64</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>mincore.lib;kernel32.lib;ole32.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <OutputFile>$(OutDir)$(ProjectName)$(TargetExt)</OutputFile>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
     </Link>
     <ClCompile>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -120,6 +127,8 @@
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <CompileAsManaged>false</CompileAsManaged>
+      <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -128,6 +137,7 @@
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories); $(VCInstallDir)\lib\store\amd64; $(VCInstallDir)\lib\amd64</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>mincore.lib;kernel32.lib;ole32.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <OutputFile>$(OutDir)$(ProjectName)$(TargetExt)</OutputFile>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
     </Link>
     <ClCompile>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -138,6 +148,8 @@
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <CompileAsManaged>false</CompileAsManaged>
+      <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -146,6 +158,7 @@
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories); $(VCInstallDir)\lib\store\amd64; $(VCInstallDir)\lib\amd64</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>mincore.lib;kernel32.lib;ole32.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <OutputFile>$(OutDir)$(ProjectName)$(TargetExt)</OutputFile>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
     </Link>
     <ClCompile>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -156,6 +169,8 @@
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <CompileAsManaged>false</CompileAsManaged>
+      <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
@@ -164,6 +179,7 @@
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories); $(VCInstallDir)\lib\store\amd64; $(VCInstallDir)\lib\amd64</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>mincore.lib;kernel32.lib;ole32.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <OutputFile>$(OutDir)$(ProjectName)$(TargetExt)</OutputFile>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
     </Link>
     <ClCompile>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -174,6 +190,8 @@
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <CompileAsManaged>false</CompileAsManaged>
+      <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/SpatialInput/Samples/DemoRoom/Package.appxmanifest
+++ b/SpatialInput/Samples/DemoRoom/Package.appxmanifest
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
-  <Identity Name="4a74e3d1-f682-43a7-adc2-c6ebeab08075" Publisher="CN=Microsoft" Version="1.0.0.0" />
+  <Identity Name="4a74e3d1-f682-43a7-adc2-c6ebeab08075" Publisher="CN=Microsoft" Version="1.1801.0.0" />
   <mp:PhoneIdentity PhoneProductId="4a74e3d1-f682-43a7-adc2-c6ebeab08075" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>DemoRoom</DisplayName>

--- a/SpatialInput/Samples/DemoRoom/PaintStrokeSystem.cpp
+++ b/SpatialInput/Samples/DemoRoom/PaintStrokeSystem.cpp
@@ -38,8 +38,11 @@ void PaintStrokeSystem::Update(float)
             Pbr::Primitive strokePrimitive(*m_pbrResources, paintStroke->GetPrimitiveData(), std::move(strokeMaterial));
 
             // Add the primitive into the model.
-            pbr->Model->Clear();
-            pbr->Model->AddPrimitive(std::move(strokePrimitive));
+            if (auto& model = pbr->Model)
+            {
+                model->Clear();
+                model->AddPrimitive(std::move(strokePrimitive));
+            }
 
             paintStroke->strokeChanged = false;
         }

--- a/SpatialInput/Samples/DemoRoom/PaintingSystem.cpp
+++ b/SpatialInput/Samples/DemoRoom/PaintingSystem.cpp
@@ -179,9 +179,10 @@ void PaintingInteractionSystem::OnSourceUpdated(const SpatialInteractionSourceEv
         auto paint = std::get<PaintComponent*>(*enabledEntity);
 
         const auto& paintBrushModel = paint->paintBrush->Get<PbrRenderable>()->Model;
-        if (std::optional<Pbr::NodeIndex_t> touchNode = paintBrushModel->FindFirstNode("PaintTip"))
+        if (paintBrushModel && !paint->brushTipOffsetFromHoldingPose)
         {
-            if (!paint->brushTipOffsetFromHoldingPose)
+            std::optional<Pbr::NodeIndex_t> touchNode = paintBrushModel->FindFirstNode("PaintTip");
+            if (touchNode)
             {
                 // Calcluate paint tip offset from holding pose
                 // we use offset as it does not rely on the current transform of the model

--- a/SpatialInput/Samples/RenderController/AppView.cpp
+++ b/SpatialInput/Samples/RenderController/AppView.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (C) Microsoft Corporation.  All Rights Reserved
+// Licensed under the MIT License. See License.txt in the project root for license information.
+#include "pch.h"
 #include "AppView.h"
 
 using namespace ControllerRenderSample;
@@ -14,9 +17,9 @@ using namespace winrt::Windows::Graphics::Holographic;
 using namespace winrt::Windows::UI::Core;
 
 // The main function bootstraps into the IFrameworkView.
-[Platform::MTAThread]
 int __stdcall wWinMain(HINSTANCE, HINSTANCE, PWSTR, int)
 {
+    winrt::init_apartment();
     CoreApplication::Run(AppViewSource());
     return 0;
 }
@@ -200,3 +203,4 @@ void AppView::OnKeyPressed(CoreWindow const& sender, KeyEventArgs const& args)
     // You can use this method for keyboard input if you want to support
     // it as an optional input method for your holographic app.
 }
+

--- a/SpatialInput/Samples/RenderController/AppView.h
+++ b/SpatialInput/Samples/RenderController/AppView.h
@@ -1,3 +1,6 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (C) Microsoft Corporation.  All Rights Reserved
+// Licensed under the MIT License. See License.txt in the project root for license information.
 #pragma once
 
 #include "Common\DeviceResources.h"
@@ -58,3 +61,4 @@ namespace ControllerRenderSample
         AppView holographicView;
     };
 }
+

--- a/SpatialInput/Samples/RenderController/Common/CameraResources.cpp
+++ b/SpatialInput/Samples/RenderController/Common/CameraResources.cpp
@@ -1,3 +1,6 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (C) Microsoft Corporation.  All Rights Reserved
+// Licensed under the MIT License. See License.txt in the project root for license information.
 #include "pch.h"
 
 #include "CameraResources.h"

--- a/SpatialInput/Samples/RenderController/Common/CameraResources.h
+++ b/SpatialInput/Samples/RenderController/Common/CameraResources.h
@@ -1,3 +1,6 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (C) Microsoft Corporation.  All Rights Reserved
+// Licensed under the MIT License. See License.txt in the project root for license information.
 #pragma once
 
 namespace DX
@@ -62,3 +65,4 @@ namespace DX
         winrt::Windows::Graphics::Holographic::HolographicCamera    m_holographicCamera = nullptr;
     };
 }
+

--- a/SpatialInput/Samples/RenderController/Common/DeviceResources.cpp
+++ b/SpatialInput/Samples/RenderController/Common/DeviceResources.cpp
@@ -1,4 +1,7 @@
-﻿
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (C) Microsoft Corporation.  All Rights Reserved
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 #include "pch.h"
 #include "DeviceResources.h"
 #include "DirectXHelper.h"
@@ -315,3 +318,4 @@ void DX::DeviceResources::Present(HolographicFrame frame)
         HandleDeviceLost();
     }
 }
+

--- a/SpatialInput/Samples/RenderController/Common/DeviceResources.h
+++ b/SpatialInput/Samples/RenderController/Common/DeviceResources.h
@@ -1,4 +1,7 @@
-﻿
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (C) Microsoft Corporation.  All Rights Reserved
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 #pragma once
 
 #include "CameraResources.h"
@@ -104,4 +107,5 @@ RetType DX::DeviceResources::UseHolographicCameraResources(LCallback const& call
     std::lock_guard<std::mutex> guard(m_cameraResourcesLock);
     return callback(m_cameraResources);
 }
+
 

--- a/SpatialInput/Samples/RenderController/Common/DirectXHelper.h
+++ b/SpatialInput/Samples/RenderController/Common/DirectXHelper.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (C) Microsoft Corporation.  All Rights Reserved
+// Licensed under the MIT License. See License.txt in the project root for license information.
+#pragma once
 
 namespace DX
 {
@@ -44,3 +47,4 @@ namespace DX
     }
 #endif
 }
+

--- a/SpatialInput/Samples/RenderController/Common/StepTimer.h
+++ b/SpatialInput/Samples/RenderController/Common/StepTimer.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (C) Microsoft Corporation.  All Rights Reserved
+// Licensed under the MIT License. See License.txt in the project root for license information.
+#pragma once
 
 namespace DX
 {
@@ -24,52 +27,52 @@ namespace DX
         }
 
         // Get elapsed time since the previous Update call.
-        uint64 GetElapsedTicks() const                        { return m_elapsedTicks;                  }
-        double GetElapsedSeconds() const                      { return TicksToSeconds(m_elapsedTicks);  }
+        uint64_t GetElapsedTicks() const { return m_elapsedTicks; }
+        double GetElapsedSeconds() const { return TicksToSeconds(m_elapsedTicks); }
 
         // Get total time since the start of the program.
-        uint64 GetTotalTicks() const                          { return m_totalTicks;                    }
-        double GetTotalSeconds() const                        { return TicksToSeconds(m_totalTicks);    }
+        uint64_t GetTotalTicks() const { return m_totalTicks; }
+        double GetTotalSeconds() const { return TicksToSeconds(m_totalTicks); }
 
         // Get total number of updates since start of the program.
-        uint32 GetFrameCount() const                          { return m_frameCount;                    }
+        uint32_t GetFrameCount() const { return m_frameCount; }
 
         // Get the current framerate.
-        uint32 GetFramesPerSecond() const                     { return m_framesPerSecond;               }
+        uint32_t GetFramesPerSecond() const { return m_framesPerSecond; }
 
         // Set whether to use fixed or variable timestep mode.
-        void SetFixedTimeStep(bool isFixedTimestep)           { m_isFixedTimeStep = isFixedTimestep;    }
+        void SetFixedTimeStep(bool isFixedTimestep) { m_isFixedTimeStep = isFixedTimestep; }
 
         // Set how often to call Update when in fixed timestep mode.
-        void SetTargetElapsedTicks(uint64 targetElapsed)      { m_targetElapsedTicks = targetElapsed;   }
-        void SetTargetElapsedSeconds(double targetElapsed)    { m_targetElapsedTicks = SecondsToTicks(targetElapsed);   }
+        void SetTargetElapsedTicks(uint64_t targetElapsed) { m_targetElapsedTicks = targetElapsed; }
+        void SetTargetElapsedSeconds(double targetElapsed) { m_targetElapsedTicks = SecondsToTicks(targetElapsed); }
 
         // Integer format represents time using 10,000,000 ticks per second.
-        static const uint64 TicksPerSecond = 10'000'000;
+        static const uint64_t TicksPerSecond = 10'000'000;
 
-        static double TicksToSeconds(uint64 ticks)            { return static_cast<double>(ticks) / TicksPerSecond;     }
-        static uint64 SecondsToTicks(double seconds)          { return static_cast<uint64>(seconds * TicksPerSecond);   }
+        static double TicksToSeconds(uint64_t ticks) { return static_cast<double>(ticks) / TicksPerSecond; }
+        static uint64_t SecondsToTicks(double seconds) { return static_cast<uint64_t>(seconds * TicksPerSecond); }
 
         // Convenient wrapper for QueryPerformanceFrequency. Throws an exception if
         // the call to QueryPerformanceFrequency fails.
-        static inline uint64 GetPerformanceFrequency()
+        static inline uint64_t GetPerformanceFrequency()
         {
             LARGE_INTEGER freq;
             if (!QueryPerformanceFrequency(&freq))
             {
-                throw ref new Platform::FailureException();
+                winrt::throw_last_error();
             }
             return freq.QuadPart;
         }
 
         // Gets the current number of ticks from QueryPerformanceCounter. Throws an
         // exception if the call to QueryPerformanceCounter fails.
-        static inline int64 GetTicks()
+        static inline int64_t GetTicks()
         {
             LARGE_INTEGER ticks;
             if (!QueryPerformanceCounter(&ticks))
             {
-                throw ref new Platform::FailureException();
+                winrt::throw_last_error();
             }
             return ticks.QuadPart;
         }
@@ -82,8 +85,8 @@ namespace DX
         {
             m_qpcLastTime = GetTicks();
 
-            m_leftOverTicks    = 0;
-            m_framesPerSecond  = 0;
+            m_leftOverTicks = 0;
+            m_framesPerSecond = 0;
             m_framesThisSecond = 0;
             m_qpcSecondCounter = 0;
         }
@@ -93,10 +96,10 @@ namespace DX
         void Tick(const TUpdate& update)
         {
             // Query the current time.
-            uint64 currentTime = GetTicks();
-            uint64 timeDelta   = currentTime - m_qpcLastTime;
+            uint64_t currentTime = GetTicks();
+            uint64_t timeDelta = currentTime - m_qpcLastTime;
 
-            m_qpcLastTime      = currentTime;
+            m_qpcLastTime = currentTime;
             m_qpcSecondCounter += timeDelta;
 
             // Clamp excessively large time deltas (e.g. after paused in the debugger).
@@ -109,7 +112,7 @@ namespace DX
             timeDelta *= TicksPerSecond;
             timeDelta /= m_qpcFrequency;
 
-            uint32 lastFrameCount = m_frameCount;
+            uint32_t lastFrameCount = m_frameCount;
 
             if (m_isFixedTimeStep)
             {
@@ -122,7 +125,7 @@ namespace DX
                 // accumulate enough tiny errors that it would drop a frame. It is better to just round
                 // small deviations down to zero to leave things running smoothly.
 
-                if (abs(static_cast<int64>(timeDelta - m_targetElapsedTicks)) < TicksPerSecond / 4000)
+                if (abs(static_cast<int64_t>(timeDelta - m_targetElapsedTicks)) < TicksPerSecond / 4000)
                 {
                     timeDelta = m_targetElapsedTicks;
                 }
@@ -131,8 +134,8 @@ namespace DX
 
                 while (m_leftOverTicks >= m_targetElapsedTicks)
                 {
-                    m_elapsedTicks   = m_targetElapsedTicks;
-                    m_totalTicks    += m_targetElapsedTicks;
+                    m_elapsedTicks = m_targetElapsedTicks;
+                    m_totalTicks += m_targetElapsedTicks;
                     m_leftOverTicks -= m_targetElapsedTicks;
                     m_frameCount++;
 
@@ -142,8 +145,8 @@ namespace DX
             else
             {
                 // Variable timestep update logic.
-                m_elapsedTicks  = timeDelta;
-                m_totalTicks   += timeDelta;
+                m_elapsedTicks = timeDelta;
+                m_totalTicks += timeDelta;
                 m_leftOverTicks = 0;
                 m_frameCount++;
 
@@ -156,10 +159,10 @@ namespace DX
                 m_framesThisSecond++;
             }
 
-            if (m_qpcSecondCounter >= static_cast<uint64>(m_qpcFrequency))
+            if (m_qpcSecondCounter >= static_cast<uint64_t>(m_qpcFrequency))
             {
-                m_framesPerSecond   = m_framesThisSecond;
-                m_framesThisSecond  = 0;
+                m_framesPerSecond = m_framesThisSecond;
+                m_framesThisSecond = 0;
                 m_qpcSecondCounter %= m_qpcFrequency;
             }
         }
@@ -167,23 +170,24 @@ namespace DX
     private:
 
         // Source timing data uses QPC units.
-        uint64 m_qpcFrequency;
-        uint64 m_qpcLastTime;
-        uint64 m_qpcMaxDelta;
+        uint64_t m_qpcFrequency;
+        uint64_t m_qpcLastTime;
+        uint64_t m_qpcMaxDelta;
 
         // Derived timing data uses a canonical tick format.
-        uint64 m_elapsedTicks;
-        uint64 m_totalTicks;
-        uint64 m_leftOverTicks;
+        uint64_t m_elapsedTicks;
+        uint64_t m_totalTicks;
+        uint64_t m_leftOverTicks;
 
         // Members for tracking the framerate.
-        uint32 m_frameCount;
-        uint32 m_framesPerSecond;
-        uint32 m_framesThisSecond;
-        uint64 m_qpcSecondCounter;
+        uint32_t m_frameCount;
+        uint32_t m_framesPerSecond;
+        uint32_t m_framesThisSecond;
+        uint64_t m_qpcSecondCounter;
 
         // Members for configuring fixed timestep mode.
         bool   m_isFixedTimeStep;
-        uint64 m_targetElapsedTicks;
+        uint64_t m_targetElapsedTicks;
     };
 }
+

--- a/SpatialInput/Samples/RenderController/ControllerRenderSample.sln
+++ b/SpatialInput/Samples/RenderController/ControllerRenderSample.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.12
+VisualStudioVersion = 15.0.27004.2006
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ControllerRenderSample", "ControllerRenderSample.vcxproj", "{0ACFCD90-BE89-11E7-ABC4-CEC278B6B50A}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -25,13 +25,17 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{0ACFCD90-BE89-11E7-ABC4-CEC278B6B50A}.Debug|ARM.ActiveCfg = Debug|ARM
+		{0ACFCD90-BE89-11E7-ABC4-CEC278B6B50A}.Debug|ARM.Build.0 = Debug|ARM
+		{0ACFCD90-BE89-11E7-ABC4-CEC278B6B50A}.Debug|ARM.Deploy.0 = Debug|ARM
 		{0ACFCD90-BE89-11E7-ABC4-CEC278B6B50A}.Debug|x64.ActiveCfg = Debug|x64
 		{0ACFCD90-BE89-11E7-ABC4-CEC278B6B50A}.Debug|x64.Build.0 = Debug|x64
 		{0ACFCD90-BE89-11E7-ABC4-CEC278B6B50A}.Debug|x64.Deploy.0 = Debug|x64
 		{0ACFCD90-BE89-11E7-ABC4-CEC278B6B50A}.Debug|x86.ActiveCfg = Debug|Win32
 		{0ACFCD90-BE89-11E7-ABC4-CEC278B6B50A}.Debug|x86.Build.0 = Debug|Win32
 		{0ACFCD90-BE89-11E7-ABC4-CEC278B6B50A}.Debug|x86.Deploy.0 = Debug|Win32
-		{0ACFCD90-BE89-11E7-ABC4-CEC278B6B50A}.Release|ARM.ActiveCfg = Release|Win32
+		{0ACFCD90-BE89-11E7-ABC4-CEC278B6B50A}.Release|ARM.ActiveCfg = Release|ARM
+		{0ACFCD90-BE89-11E7-ABC4-CEC278B6B50A}.Release|ARM.Build.0 = Release|ARM
+		{0ACFCD90-BE89-11E7-ABC4-CEC278B6B50A}.Release|ARM.Deploy.0 = Release|ARM
 		{0ACFCD90-BE89-11E7-ABC4-CEC278B6B50A}.Release|x64.ActiveCfg = Release|x64
 		{0ACFCD90-BE89-11E7-ABC4-CEC278B6B50A}.Release|x64.Build.0 = Release|x64
 		{0ACFCD90-BE89-11E7-ABC4-CEC278B6B50A}.Release|x64.Deploy.0 = Release|x64
@@ -51,11 +55,13 @@ Global
 		{63475578-0C83-4B2F-9AC5-A4513DE2907F}.Release|x86.ActiveCfg = Release|Win32
 		{63475578-0C83-4B2F-9AC5-A4513DE2907F}.Release|x86.Build.0 = Release|Win32
 		{30B0D5F4-52B6-4083-8607-D80D844D9DD7}.Debug|ARM.ActiveCfg = Debug|ARM
+		{30B0D5F4-52B6-4083-8607-D80D844D9DD7}.Debug|ARM.Build.0 = Debug|ARM
 		{30B0D5F4-52B6-4083-8607-D80D844D9DD7}.Debug|x64.ActiveCfg = Debug|x64
 		{30B0D5F4-52B6-4083-8607-D80D844D9DD7}.Debug|x64.Build.0 = Debug|x64
 		{30B0D5F4-52B6-4083-8607-D80D844D9DD7}.Debug|x86.ActiveCfg = Debug|Win32
 		{30B0D5F4-52B6-4083-8607-D80D844D9DD7}.Debug|x86.Build.0 = Debug|Win32
-		{30B0D5F4-52B6-4083-8607-D80D844D9DD7}.Release|ARM.ActiveCfg = Release|Win32
+		{30B0D5F4-52B6-4083-8607-D80D844D9DD7}.Release|ARM.ActiveCfg = Release|ARM
+		{30B0D5F4-52B6-4083-8607-D80D844D9DD7}.Release|ARM.Build.0 = Release|ARM
 		{30B0D5F4-52B6-4083-8607-D80D844D9DD7}.Release|x64.ActiveCfg = Release|x64
 		{30B0D5F4-52B6-4083-8607-D80D844D9DD7}.Release|x64.Build.0 = Release|x64
 		{30B0D5F4-52B6-4083-8607-D80D844D9DD7}.Release|x86.ActiveCfg = Release|Win32

--- a/SpatialInput/Samples/RenderController/ControllerRenderSample.vcxproj
+++ b/SpatialInput/Samples/RenderController/ControllerRenderSample.vcxproj
@@ -101,6 +101,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <PackageCertificateKeyFile>ControllerRenderSample_TemporaryKey.pfx</PackageCertificateKeyFile>
+    <AppxBundle>Always</AppxBundle>
+    <AppxBundlePlatforms>x86|x64</AppxBundlePlatforms>
     <AppxAutoIncrementPackageRevision>True</AppxAutoIncrementPackageRevision>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -108,6 +110,7 @@
       <AdditionalDependencies>d2d1.lib; d3d11.lib; dxgi.lib; dwrite.lib; windowscodecs.lib; %(AdditionalDependencies); </AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories); $(VCInstallDir)\lib\store; $(VCInstallDir)\lib</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>mincore.lib;kernel32.lib;ole32.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
     </Link>
     <ClCompile>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -116,6 +119,8 @@
       <AdditionalOptions>/bigobj /await /std:c++latest  %(AdditionalOptions)</AdditionalOptions>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAsWinRT>false</CompileAsWinRT>
+      <CompileAsManaged>false</CompileAsManaged>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -123,6 +128,7 @@
       <AdditionalDependencies>d2d1.lib; d3d11.lib; dxgi.lib; dwrite.lib; windowscodecs.lib; %(AdditionalDependencies); </AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories); $(VCInstallDir)\lib\store; $(VCInstallDir)\lib</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>mincore.lib;kernel32.lib;ole32.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
     </Link>
     <ClCompile>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -131,6 +137,8 @@
       <AdditionalOptions>/bigobj /await /std:c++latest  %(AdditionalOptions)</AdditionalOptions>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAsWinRT>false</CompileAsWinRT>
+      <CompileAsManaged>false</CompileAsManaged>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -138,6 +146,7 @@
       <AdditionalDependencies>d2d1.lib; d3d11.lib; dxgi.lib; dwrite.lib; windowscodecs.lib; %(AdditionalDependencies); </AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories); $(VCInstallDir)\lib\store; $(VCInstallDir)\lib</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>mincore.lib;kernel32.lib;ole32.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
     </Link>
     <ClCompile>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -146,6 +155,8 @@
       <AdditionalOptions>/bigobj /await /std:c++latest  %(AdditionalOptions)</AdditionalOptions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAsWinRT>false</CompileAsWinRT>
+      <CompileAsManaged>false</CompileAsManaged>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
@@ -153,6 +164,7 @@
       <AdditionalDependencies>d2d1.lib; d3d11.lib; dxgi.lib; dwrite.lib; windowscodecs.lib; %(AdditionalDependencies); </AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories); $(VCInstallDir)\lib\store; $(VCInstallDir)\lib</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>mincore.lib;kernel32.lib;ole32.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
     </Link>
     <ClCompile>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -161,6 +173,8 @@
       <AdditionalOptions>/bigobj /await /std:c++latest  %(AdditionalOptions)</AdditionalOptions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAsWinRT>false</CompileAsWinRT>
+      <CompileAsManaged>false</CompileAsManaged>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -168,6 +182,7 @@
       <AdditionalDependencies>d2d1.lib; d3d11.lib; dxgi.lib; dwrite.lib; windowscodecs.lib; %(AdditionalDependencies); </AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories); $(VCInstallDir)\lib\store\amd64; $(VCInstallDir)\lib\amd64</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>mincore.lib;kernel32.lib;ole32.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
     </Link>
     <ClCompile>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -176,6 +191,8 @@
       <AdditionalOptions>/bigobj /await /std:c++latest  %(AdditionalOptions)</AdditionalOptions>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAsWinRT>false</CompileAsWinRT>
+      <CompileAsManaged>false</CompileAsManaged>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -183,6 +200,7 @@
       <AdditionalDependencies>d2d1.lib; d3d11.lib; dxgi.lib; dwrite.lib; windowscodecs.lib; %(AdditionalDependencies); </AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories); $(VCInstallDir)\lib\store\amd64; $(VCInstallDir)\lib\amd64</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>mincore.lib;kernel32.lib;ole32.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
     </Link>
     <ClCompile>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -191,6 +209,8 @@
       <AdditionalOptions>/bigobj /await /std:c++latest  %(AdditionalOptions)</AdditionalOptions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAsWinRT>false</CompileAsWinRT>
+      <CompileAsManaged>false</CompileAsManaged>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/SpatialInput/Samples/RenderController/ControllerRenderSampleMain.cpp
+++ b/SpatialInput/Samples/RenderController/ControllerRenderSampleMain.cpp
@@ -1,3 +1,6 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (C) Microsoft Corporation.  All Rights Reserved
+// Licensed under the MIT License. See License.txt in the project root for license information.
 #include "pch.h"
 #include <DirectXTK\DDSTextureLoader.h>
 #include "Common\DirectXHelper.h"
@@ -7,7 +10,6 @@ using namespace ControllerRenderSample;
 
 using namespace concurrency;
 using namespace DirectX;
-using namespace Platform;
 using namespace std::placeholders;
 using namespace winrt::Windows::Foundation::Numerics;
 using namespace winrt::Windows::Gaming::Input;
@@ -431,3 +433,4 @@ void ControllerRenderSampleMain::OnCameraRemoved(
     // not take long.
     m_deviceResources->RemoveHolographicCamera(args.Camera());
 }
+

--- a/SpatialInput/Samples/RenderController/ControllerRenderSampleMain.h
+++ b/SpatialInput/Samples/RenderController/ControllerRenderSampleMain.h
@@ -1,3 +1,6 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (C) Microsoft Corporation.  All Rights Reserved
+// Licensed under the MIT License. See License.txt in the project root for license information.
 #pragma once
 
 //
@@ -107,3 +110,4 @@ namespace ControllerRenderSample
         winrt::event_token                                          m_locatabilityChangedToken;
     };
 }
+

--- a/SpatialInput/Samples/RenderController/ControllerRenderer.cpp
+++ b/SpatialInput/Samples/RenderController/ControllerRenderer.cpp
@@ -1,3 +1,6 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (C) Microsoft Corporation.  All Rights Reserved
+// Licensed under the MIT License. See License.txt in the project root for license information.
 #include "pch.h"
 #include "ControllerRenderer.h"
 #include "Common\DirectXHelper.h"

--- a/SpatialInput/Samples/RenderController/ControllerRenderer.h
+++ b/SpatialInput/Samples/RenderController/ControllerRenderer.h
@@ -1,3 +1,6 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (C) Microsoft Corporation.  All Rights Reserved
+// Licensed under the MIT License. See License.txt in the project root for license information.
 #pragma once
 
 #include <SpatialInputUtilities\ControllerRendering.h>
@@ -44,3 +47,4 @@ namespace ControllerRenderSample
         ControllerRendering::ControllerModelCache m_controllerModelCache;
     };
 }
+

--- a/SpatialInput/Samples/RenderController/SpinningCubeRenderer.cpp
+++ b/SpatialInput/Samples/RenderController/SpinningCubeRenderer.cpp
@@ -1,3 +1,6 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (C) Microsoft Corporation.  All Rights Reserved
+// Licensed under the MIT License. See License.txt in the project root for license information.
 #include "pch.h"
 #include "SpinningCubeRenderer.h"
 #include "Common\DirectXHelper.h"
@@ -80,3 +83,4 @@ void SpinningCubeRenderer::ReleaseDeviceDependentResources()
     m_loadingComplete  = false;
     m_cubeModel.reset();
 }
+

--- a/SpatialInput/Samples/RenderController/SpinningCubeRenderer.h
+++ b/SpatialInput/Samples/RenderController/SpinningCubeRenderer.h
@@ -1,3 +1,6 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (C) Microsoft Corporation.  All Rights Reserved
+// Licensed under the MIT License. See License.txt in the project root for license information.
 #pragma once
 
 #include "..\Common\DeviceResources.h"
@@ -38,3 +41,4 @@ namespace ControllerRenderSample
         winrt::Windows::Foundation::Numerics::quaternion m_orientation { winrt::Windows::Foundation::Numerics::quaternion::identity() };
     };
 }
+

--- a/SpatialInput/Samples/RenderController/pch.cpp
+++ b/SpatialInput/Samples/RenderController/pch.cpp
@@ -1,6 +1,10 @@
-﻿//
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (C) Microsoft Corporation.  All Rights Reserved
+// Licensed under the MIT License. See License.txt in the project root for license information.
+//
 // pch.cpp
 // Include the standard header and generate the precompiled header.
 //
 
 #include "pch.h"
+

--- a/SpatialInput/Samples/RenderController/pch.h
+++ b/SpatialInput/Samples/RenderController/pch.h
@@ -1,6 +1,8 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (C) Microsoft Corporation.  All Rights Reserved
+// Licensed under the MIT License. See License.txt in the project root for license information.
 #pragma once
 
-#include <agile.h>
 #include <array>
 #include <d2d1_2.h>
 #include <d3d11_4.h>
@@ -14,6 +16,8 @@
 #include <WindowsNumerics.h>
 
 #include <Windows.Graphics.Directx.Direct3D11.Interop.h>
+
+#include <wrl/client.h>
 
 #include <winrt\base.h>
 #include <winrt\Windows.ApplicationModel.Activation.h>
@@ -30,6 +34,3 @@
 #include <winrt\Windows.UI.Core.h>
 #include <winrt\Windows.UI.Input.Spatial.h>
 
-// For range-based for loops on IVectorView.
-// Works with CPPWinRT.
-#include <collection.h>


### PR DESCRIPTION
1. Fixed a few crashing bugs
2. Removed remaining project dependency to c++/cx
3. Added some missing licensing headers.