### PR TITLE
[(Error: Fatal Error C1107) Project Setting Issue for compiling under non-Enterprise VS2017

### DIFF
--- a/Input/MicStreamSelector/Projects/MicStreamSelector_Win32/MicStreamSelector.vcxproj
+++ b/Input/MicStreamSelector/Projects/MicStreamSelector_Win32/MicStreamSelector.vcxproj
@@ -145,7 +145,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <CompileAsWinRT>true</CompileAsWinRT>
       <MinimalRebuild>false</MinimalRebuild>
-      <AdditionalUsingDirectories>C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\VC\vcpackages;C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.16299.0;C:\Program Files (x86)\Windows Kits\10\References\Windows.Foundation.FoundationContract\2.0.0.0;C:\Program Files (x86)\Windows Kits\10\References\Windows.Foundation.UniversalApiContract\3.0.0.0</AdditionalUsingDirectories>
+      <AdditionalUsingDirectories>$(DevEnvDir)VC\vcpackages;C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.16299.0;C:\Program Files (x86)\Windows Kits\10\References\Windows.Foundation.FoundationContract\2.0.0.0;C:\Program Files (x86)\Windows Kits\10\References\Windows.Foundation.UniversalApiContract\3.0.0.0</AdditionalUsingDirectories>
       <AdditionalIncludeDirectories>
       </AdditionalIncludeDirectories>
     </ClCompile>


### PR DESCRIPTION
[(Error: Fatal Error C1107) Project Setting Issue for compiling input/MicStreamSelector Solution]

Issue Statement:
 Program cannot assembly file "platform.winmd" when compiling the entire solution of  input/MicStreamSelector, if the compiler is non-Enterprise Visual Studio 2017
Solution:
Use a macro for the project setting.