### PR TITLE
Seek back to beginning before reading file

### DIFF
--- a/SpatialInput/External/tiny_gltf.h
+++ b/SpatialInput/External/tiny_gltf.h
@@ -1013,6 +1013,7 @@ static bool LoadExternalFile(std::vector<unsigned char> *out, std::string *err,
   }
   std::vector<unsigned char> buf(sz);
 
+  f.seekg(0, f.beg);
   f.read(reinterpret_cast<char *>(&buf.at(0)),
          static_cast<std::streamsize>(sz));
   f.close();


### PR DESCRIPTION
In the LoadExternalFile function the stream needs to seek back to the beginning before the file is read.