### PR TITLE
Suggested commit for vcpkg didn't work

### DIFF
--- a/SpectatorViewPlugin/README.md
+++ b/SpectatorViewPlugin/README.md
@@ -6,7 +6,7 @@
 - Navigate to a folder in which you would like to store your repositories (ex: c:\git)
 - git clone <https://github.com/Microsoft/vcpkg>
 - cd vcpkg
-- git checkout 56ea0dca4098754cee6dba7766c9e38d1fe40165
+- git checkout 068032bc548817a04709970f76268a6d7b1767c7
 - .\bootstrap-vcpkg.bat
 - .\vcpkg integrate install
 


### PR DESCRIPTION
The suggested commit for vcpkg failed locally for me based on a bad nuget package hash for 7-zip 18.1.0. Using 068032bc548817a04709970f76268a6d7b1767c7 with a reverted 7-zip version unblocked my local build.