### PR TITLE
Fix a few using statements in PlaneFinding test code

### DIFF
--- a/SpatialMapping/PlaneFinding/Tests/TestApp/Program.cs
+++ b/SpatialMapping/PlaneFinding/Tests/TestApp/Program.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using MixedRealityToolkit.SpatialMapping.SpatialProcessing;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
-using HoloToolkit.Unity;
 
 namespace PlaneFindingTestApp
 {

--- a/SpatialMapping/PlaneFinding/Tests/TestHelpers/Util.cs
+++ b/SpatialMapping/PlaneFinding/Tests/TestHelpers/Util.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using MixedRealityToolkit.SpatialMapping.SpatialProcessing;
 using System.Linq;
 using UnityEngine;
-using HoloToolkit.Unity;
 
 public static class Util
 {

--- a/SpatialMapping/PlaneFinding/Tests/UnitTests/TestCases.cs
+++ b/SpatialMapping/PlaneFinding/Tests/UnitTests/TestCases.cs
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MixedRealityToolkit.SpatialMapping.SpatialProcessing;
+using System.Collections.Generic;
 using UnityEngine;
-using HoloToolkit.Unity;
 
 namespace PlaneFindingUnitTests
 {


### PR DESCRIPTION
A namespace was changed, but usings weren't.