### PR TITLE
Return negative values on errors and fix null pointer crash when deinitializing

### DIFF
--- a/GpuStats/GpuStats/GpuStats.cpp
+++ b/GpuStats/GpuStats/GpuStats.cpp
@@ -128,7 +128,7 @@ public:
 			else
 			{
 				State = QueryState::Unknown;
-				*value = -1;
+				*value = -1.0; // Disjoint
 				return true;
 			}
 		}
@@ -196,14 +196,14 @@ extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginUnload()
 	}
 }
 
-extern "C" double UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API GetGpuTime(int eventId)
+extern "C" double UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API GetGpuDuration(int eventId)
 {
 	if (s_Context == nullptr)
 	{
 		return 0.0;
 	}
 
-	double time = 0;
+	double time = -2.0; // Not found
 
 	EnterCriticalSection(&updateTimingsSync);
 	auto it = s_FrameTimes.find(eventId);
@@ -251,7 +251,7 @@ static void UpdateFrameTime()
 
 		auto activeQueries = activeQueriesIt->second;
 
-		double frameTime = 0;
+		double frameTime;
 		QueryPtr q = activeQueries->front();
 
 		if (q->Read(&frameTime))

--- a/GpuStats/GpuStats/GpuStats.cpp
+++ b/GpuStats/GpuStats/GpuStats.cpp
@@ -196,7 +196,7 @@ extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginUnload()
 	}
 }
 
-extern "C" double UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API GetGpuTime(int eventId)
+extern "C" double UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API GetGpuDuration(int eventId)
 {
 	if (s_Context == nullptr)
 	{

--- a/GpuStats/GpuStats/GpuStats.cpp
+++ b/GpuStats/GpuStats/GpuStats.cpp
@@ -128,7 +128,7 @@ public:
 			else
 			{
 				State = QueryState::Unknown;
-				*value = -1.0; // Disjoint
+				*value = -1;
 				return true;
 			}
 		}
@@ -196,14 +196,14 @@ extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginUnload()
 	}
 }
 
-extern "C" double UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API GetGpuDuration(int eventId)
+extern "C" double UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API GetGpuTime(int eventId)
 {
 	if (s_Context == nullptr)
 	{
 		return 0.0;
 	}
 
-	double time = -2.0; // Not found
+	double time = 0;
 
 	EnterCriticalSection(&updateTimingsSync);
 	auto it = s_FrameTimes.find(eventId);
@@ -251,7 +251,7 @@ static void UpdateFrameTime()
 
 		auto activeQueries = activeQueriesIt->second;
 
-		double frameTime;
+		double frameTime = 0;
 		QueryPtr q = activeQueries->front();
 
 		if (q->Read(&frameTime))
@@ -368,6 +368,7 @@ static void ReleaseResources()
 	if (s_Adapter != nullptr)
 	{
 		s_Adapter->Release();
+        s_Adapter = nullptr;
 	}
 #endif
 

--- a/GpuStats/GpuStats/GpuStats.cpp
+++ b/GpuStats/GpuStats/GpuStats.cpp
@@ -368,7 +368,7 @@ static void ReleaseResources()
 	if (s_Adapter != nullptr)
 	{
 		s_Adapter->Release();
-        s_Adapter = nullptr;
+		s_Adapter = nullptr;
 	}
 #endif
 

--- a/GpuStats/GpuStats/GpuStats.cpp
+++ b/GpuStats/GpuStats/GpuStats.cpp
@@ -128,7 +128,7 @@ public:
 			else
 			{
 				State = QueryState::Unknown;
-				*value = -1;
+				*value = -1.0; // Disjoint
 				return true;
 			}
 		}
@@ -203,7 +203,7 @@ extern "C" double UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API GetGpuTime(int even
 		return 0.0;
 	}
 
-	double time = 0;
+	double time = -2.0; // Not found
 
 	EnterCriticalSection(&updateTimingsSync);
 	auto it = s_FrameTimes.find(eventId);
@@ -251,7 +251,7 @@ static void UpdateFrameTime()
 
 		auto activeQueries = activeQueriesIt->second;
 
-		double frameTime = 0;
+		double frameTime;
 		QueryPtr q = activeQueries->front();
 
 		if (q->Read(&frameTime))

--- a/GpuStats/GpuStats/UnityNativeRenderingPlugin.def
+++ b/GpuStats/GpuStats/UnityNativeRenderingPlugin.def
@@ -5,7 +5,7 @@
 LIBRARY
 
 EXPORTS
-	GetGpuTime
+	GetGpuDuration
 	GetVramUse
 	GetRenderEventFunc
 	UnityPluginLoad


### PR DESCRIPTION
Previously, one of the errors cases (query not found) would return 0, which can't be distinguished from the possible case of a query returning 0 by virtue of being too short (unlikely but not impossible).
Now errors are more clear.
Corresponding script changes in MRTK-Unity: https://github.com/botrif/MixedRealityToolkit-Unity/tree/htk_development