### PR TITLE
Refactoring SpectatorView Plugin

### DIFF
--- a/SpectatorViewPlugin/SpectatorViewPlugin/SpectatorViewPlugin/MarkerDetector.h
+++ b/SpectatorViewPlugin/SpectatorViewPlugin/SpectatorViewPlugin/MarkerDetector.h
@@ -18,9 +18,12 @@ public:
         unsigned char* imageData,
         int imageWidth,
         int imageHeight,
-        float* projectionMatrix,
+        float* focalLength,
+        float* principalPoint,
+        float* radialDistortion,
+        float* tangentialDistortion,
         float markerSize,
-        int arUcoDictionaryId);
+        int arUcoMarkerDictionaryId);
     inline int GetDetectedMarkersCount() { return _detectedMarkers.size(); }
     bool GetDetectedMarkerIds(int* _detectedIds, int size);
     bool GetDetectedMarkerPose(int _detectedId, float* position, float* rotation);

--- a/SpectatorViewPlugin/SpectatorViewPlugin/SpectatorViewPlugin/MarkerDetector.h
+++ b/SpectatorViewPlugin/SpectatorViewPlugin/SpectatorViewPlugin/MarkerDetector.h
@@ -1,21 +1,30 @@
 #pragma once
-#include<vector>
+#include<unordered_map>
 #include <opencv2\core.hpp>
+
+struct Marker
+{
+    int Id;
+    float position[3];
+    float rotation[3];
+};
 
 class MarkerDetector
 {
 public:
-	MarkerDetector(int _markerDictionaryId);
-	~MarkerDetector();
-	void Detect(int _imageWidth, int _imageHeight, unsigned char* _imageData, float _markerSize);
-	
-	inline int GetNumDetectedMarkers() { return m_detectedMarkers.size(); }
-	bool GetDetectedMarkerIds(unsigned int* _detectedMarkerIds);
-	bool GetDetectedMarkerPose(int _markerId, float& _xPos, float& _yPos, float& _zPos, float& _xRot, float& _yRot, float& _zRot);
+    MarkerDetector();
+    ~MarkerDetector();
+    bool DetectMarkers(
+        unsigned char* imageData,
+        int imageWidth,
+        int imageHeight,
+        float* projectionMatrix,
+        float markerSize,
+        int arUcoDictionaryId);
+    inline int GetDetectedMarkersCount() { return _detectedMarkers.size(); }
+    bool GetDetectedMarkerIds(int* _detectedIds, int size);
+    bool GetDetectedMarkerPose(int _detectedId, float* position, float* rotation);
+
 private:
-	std::vector<std::vector<cv::Point2f>> m_markerCorners;
-	std::vector<cv::Vec3d> m_rotationVecs;
-	std::vector<cv::Vec3d> m_translationVecs;
-	std::vector<int> m_detectedMarkers;
-	int m_dictionaryId;
+    std::unordered_map<int, Marker> _detectedMarkers;
 };

--- a/SpectatorViewPlugin/SpectatorViewPlugin/SpectatorViewPlugin/SpectatorViewPlugin.cpp
+++ b/SpectatorViewPlugin/SpectatorViewPlugin/SpectatorViewPlugin/SpectatorViewPlugin.cpp
@@ -1,6 +1,7 @@
 ﻿#include "pch.h"
 #include "SpectatorViewPlugin.h"
 #include "MarkerDetector.h"
+#include <memory>
 
 std::unique_ptr<MarkerDetector> detector;
 

--- a/SpectatorViewPlugin/SpectatorViewPlugin/SpectatorViewPlugin/SpectatorViewPlugin.cpp
+++ b/SpectatorViewPlugin/SpectatorViewPlugin/SpectatorViewPlugin/SpectatorViewPlugin.cpp
@@ -18,7 +18,10 @@ extern "C" __declspec(dllexport) bool __stdcall DetectMarkers(
     unsigned char* imageData,
     int imageWidth,
     int imageHeight,
-    float* projectionMatrix,
+    float* focalLength,
+    float* principalPoint,
+    float* radialDistortion,
+    float* tangentialDistortion,
     float markerSize,
     int arUcoMarkerDictionaryId)
 {
@@ -28,7 +31,10 @@ extern "C" __declspec(dllexport) bool __stdcall DetectMarkers(
             imageData,
             imageWidth,
             imageHeight,
-            projectionMatrix,
+            focalLength,
+            principalPoint,
+            radialDistortion,
+            tangentialDistortion,
             markerSize,
             arUcoMarkerDictionaryId);
     }

--- a/SpectatorViewPlugin/SpectatorViewPlugin/SpectatorViewPlugin/SpectatorViewPlugin.cpp
+++ b/SpectatorViewPlugin/SpectatorViewPlugin/SpectatorViewPlugin/SpectatorViewPlugin.cpp
@@ -1,97 +1,72 @@
 ﻿#include "pch.h"
 #include "SpectatorViewPlugin.h"
-#include <opencv2\aruco.hpp>
-#include <opencv2\core.hpp>
-#include <opencv2\highgui.hpp>
-#include <opencv2\aruco\charuco.hpp>
-#include <ctime>
 #include "MarkerDetector.h"
 
-MarkerDetector* detector = NULL;
+std::unique_ptr<MarkerDetector> detector;
 
-/// Void function to test whether Unity has been able to successful load the dll 
-extern "C" __declspec(dllexport) void __stdcall CheckLibraryHasLoaded()
+extern "C" __declspec(dllexport) bool __stdcall Initialize()
 {
-	return;
+    if (!detector)
+    {
+        detector = std::make_unique<MarkerDetector>();
+    }
+
+    return true;
 }
 
-extern "C" __declspec(dllexport) void __stdcall MarkerDetector_Initialize()
+extern "C" __declspec(dllexport) bool __stdcall DetectMarkers(
+    unsigned char* imageData,
+    int imageWidth,
+    int imageHeight,
+    float* projectionMatrix,
+    float markerSize,
+    int arUcoMarkerDictionaryId)
 {
-	if (detector == NULL)
-	{
-		detector = new MarkerDetector(10);
-	}
+    if (detector)
+    {
+        return detector->DetectMarkers(
+            imageData,
+            imageWidth,
+            imageHeight,
+            projectionMatrix,
+            markerSize,
+            arUcoMarkerDictionaryId);
+    }
+
+    return false;
 }
 
-extern "C" __declspec(dllexport) void __stdcall MarkerDetector_Terminate()
+extern "C" __declspec(dllexport) int __stdcall GetDetectedMarkersCount()
 {
-	if (detector != NULL)
-	{
-		delete detector;
-	}
+    if (detector)
+    {
+        return detector->GetDetectedMarkersCount();
+    }
+
+    return -1;
 }
 
-/// Looks for markers in an image
-/// _imageWidth : width of the image data
-/// _imageHeight: height of the image data
-/// _imageData : input image data
-/// _markerSize : The physical size of the target marker in meters
-extern "C" __declspec(dllexport) bool __stdcall MarkerDetector_DetectMarkers(int _imageWidth, int _imageHeight, unsigned char* _imageData, float _markerSize)
+extern "C" __declspec(dllexport) bool __stdcall GetDetectedMarkerIds(
+    int* detectedIds,
+    int size)
 {
-	if (detector == NULL)
-	{
-		return false;
-	}
+    if (detector)
+    {
+        return detector->GetDetectedMarkerIds(detectedIds, size);
+    }
 
-	detector->Detect(_imageWidth, _imageHeight, _imageData, _markerSize);
-
-	return true;
+    return false;
 }
 
-/// Returns the number of marker detected after MarkerDetector_DetectMarkers has been called 
-/// _numMarkersDetected : the number of markers detected
-extern "C" __declspec(dllexport) bool __stdcall MarkerDetector_GetNumMarkersDetected(int& _numMarkersDetected)
+extern "C" __declspec(dllexport) bool __stdcall GetDetectedMarkerPose(
+    int detectedId,
+    float* position,
+    float* rotation)
 {
-	if (detector == NULL)
-	{
-		return false;
-	}
+    if (detector)
+    {
+        return detector->GetDetectedMarkerPose(detectedId, position, rotation);
+    }
 
-	_numMarkersDetected = detector->GetNumDetectedMarkers();
-
-	return true;
-}
-
-/// Get an array of detected marker ids after MarkerDetector_DetectMarkers has been called 
-/// _detectedMarkers : array of detected marker ids
-extern "C" __declspec(dllexport) bool __stdcall MarkerDetector_GetDetectedMarkerIds(unsigned int* _detectedMarkers)
-{
-	if (detector == NULL)
-	{
-		return false;
-	}
-
-	detector->GetDetectedMarkerIds(_detectedMarkers);
-
-	return true;
-}
-
-/// Gets the marker position and rotation in camera space for a given marker
-/// _markerId : the requested marker id
-/// _xPos : x position
-/// _yPos : y position
-/// _zPos : z position
-/// _xRot : x rotation
-/// _yRot : y rotatiom
-/// _zRot : z rotation
-extern "C" __declspec(dllexport) bool __stdcall MarkerDetector_GetDetectedMarkerPose(int _markerId, float& _xPos, float& _yPos, float& _zPos, float& _xRot, float& _yRot, float& _zRot)
-{
-	if (detector == NULL)
-	{
-		return false;
-	}
-
-	detector->GetDetectedMarkerPose(_markerId, _xPos, _yPos, _zPos, _xRot, _yRot, _zRot);
-
-	return true;
+    return false;
 }

--- a/SpectatorViewPlugin/SpectatorViewPlugin/SpectatorViewPlugin/SpectatorViewPlugin.vcxproj
+++ b/SpectatorViewPlugin/SpectatorViewPlugin/SpectatorViewPlugin/SpectatorViewPlugin.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10586.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <ProjectName>SpectatorViewPlugin</ProjectName>


### PR DESCRIPTION
This refactor is related to work in https://github.com/Microsoft/MixedRealityToolkit-Unity/tree/feature/spectatorView 

Changes include the following:
1) The dll is reformatted so that plugin functions use float arrays/pointers. This avoids having to call unsafe code in the C# wrapper class within unity.
2) The dll is reformatted to require camera intrinsic and lens distortion values when detecting markers. These values can be obtained via a new HoloLensCamera wrapper  (https://github.com/chrisfromwork/MixedRealityToolkit-Unity/blob/refactorMarkerDetection/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Utilities/HoloLensCamera.cs )