### PR TITLE
Fix a bad function name

### DIFF
--- a/SpectatorViewPlugin/SpectatorViewPlugin/SpectatorViewPlugin.Editor/SpectatorViewPlugin.Editor.cpp
+++ b/SpectatorViewPlugin/SpectatorViewPlugin/SpectatorViewPlugin.Editor/SpectatorViewPlugin.Editor.cpp
@@ -70,7 +70,7 @@ extern "C" __declspec(dllexport) int __stdcall GetDetectedMarkersCount()
 // Returns False if the array size is less than the number of detected markers
 // detectedIds - int[] populated with ids
 // size - size of the int[]
-extern "C" __declspec(dllexport) bool __stdcall GetDetectedMarkerids(
+extern "C" __declspec(dllexport) bool __stdcall GetDetectedMarkerIds(
     int* detectedIds,
     int size)
 {

--- a/SpectatorViewPlugin/SpectatorViewPlugin/SpectatorViewPlugin.Unity.nuspec
+++ b/SpectatorViewPlugin/SpectatorViewPlugin/SpectatorViewPlugin.Unity.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Microsoft.SpectatorViewPlugin.Unity</id>
-    <version>0.0.1</version>
+    <version>0.0.2</version>
     <description>This is a test NuGet package definition for distributing the Spectator View binaries and their dependencies. Binaries will be output into the proper Unity Plugins special folder.</description>
     <authors>Unknown</authors>
     <licenseUrl>https://github.com/Microsoft/MixedRealityToolkit/blob/master/License.txt</licenseUrl>

--- a/SpectatorViewPlugin/SpectatorViewPlugin/SpectatorViewPlugin/SpectatorViewPlugin.cpp
+++ b/SpectatorViewPlugin/SpectatorViewPlugin/SpectatorViewPlugin/SpectatorViewPlugin.cpp
@@ -71,7 +71,7 @@ extern "C" __declspec(dllexport) int __stdcall GetDetectedMarkersCount()
 // Returns False if the array size is less than the number of detected markers
 // detectedIds - int[] populated with ids
 // size - size of the int[]
-extern "C" __declspec(dllexport) bool __stdcall GetDetectedMarkerids(
+extern "C" __declspec(dllexport) bool __stdcall GetDetectedMarkerIds(
     int* detectedIds,
     int size)
 {


### PR DESCRIPTION
Some how "ids" lost its capitalization breaking our dll import.