### PR TITLE
Ensure the detected markers set from the previous detection is cleared

### DIFF
--- a/SpectatorViewPlugin/SpectatorViewPlugin/SharedFiles/ArUcoMarkerDetector.cpp
+++ b/SpectatorViewPlugin/SpectatorViewPlugin/SharedFiles/ArUcoMarkerDetector.cpp
@@ -90,6 +90,7 @@ bool ArUcoMarkerDetector::DetectMarkers(
         rotationVecs,
         translationVecs);
 
+    _detectedMarkers.clear();
     for (size_t i = 0; i < arUcoMarkerIds.size(); i++)
     {
         auto id = arUcoMarkerIds[i];


### PR DESCRIPTION
This change makes sure that the _detectedMarkers set is cleared before populating it with the results of a new detection. Prior to this, if a marker was detected previously but not in the current image, its stale data would be reported again.