### PR TITLE
Port some changes from the HTK-checked-in version of PlaneFinding (and formatting)

### DIFF
--- a/SpatialMapping/PlaneFinding/Tests/TestHelpers/Util.cs
+++ b/SpatialMapping/PlaneFinding/Tests/TestHelpers/Util.cs
@@ -45,11 +45,13 @@ public static class Util
                 })
             ).ToArray();
 
-        PlaneFinding.MeshData mesh = new PlaneFinding.MeshData();
-        mesh.Transform = meshTransform;
-        mesh.Verts = vertices;
-        mesh.Normals = normals;
-        mesh.Indices = indices;
+        PlaneFinding.MeshData mesh = new PlaneFinding.MeshData
+        (
+            transform: meshTransform,
+            vertices: vertices,
+            normals: normals,
+            indices: indices
+        );
         return mesh;
     }
 

--- a/SpatialMapping/PlaneFinding/UnityAddon/PlaneFinding.cs
+++ b/SpatialMapping/PlaneFinding/UnityAddon/PlaneFinding.cs
@@ -40,17 +40,25 @@ namespace MixedRealityToolkit.SpatialMapping.SpatialProcessing
         /// </summary>
         public readonly struct MeshData
         {
-            public Matrix4x4 Transform { get; }
-            public Vector3[] Verts { get; }
-            public Vector3[] Normals { get; }
-            public int[] Indices { get; }
+            internal Matrix4x4 Transform { get; }
+            internal Vector3[] Vertices { get; }
+            internal Vector3[] Normals { get; }
+            internal int[] Indices { get; }
 
             public MeshData(MeshFilter meshFilter)
             {
                 Transform = meshFilter.transform.localToWorldMatrix;
-                Verts = meshFilter.sharedMesh.vertices;
+                Vertices = meshFilter.sharedMesh.vertices;
                 Normals = meshFilter.sharedMesh.normals;
                 Indices = meshFilter.sharedMesh.triangles;
+            }
+
+            internal MeshData(Matrix4x4 transform, Vector3[] vertices, Vector3[] normals, int[] indices)
+            {
+                Transform = transform;
+                Vertices = vertices;
+                Normals = normals;
+                Indices = indices;
             }
         }
 
@@ -242,9 +250,9 @@ namespace MixedRealityToolkit.SpatialMapping.SpatialProcessing
                 reusedMeshesForMarshalling[i] = new DLLImports.MeshData()
                 {
                     transform = meshes[i].Transform,
-                    vertCount = meshes[i].Verts.Length,
+                    vertCount = meshes[i].Vertices.Length,
                     indexCount = meshes[i].Indices.Length,
-                    verts = PinObject(meshes[i].Verts),
+                    verts = PinObject(meshes[i].Vertices),
                     normals = PinObject(meshes[i].Normals),
                     indices = PinObject(meshes[i].Indices),
                 };

--- a/SpatialMapping/PlaneFinding/UnityAddon/PlaneFinding.cs
+++ b/SpatialMapping/PlaneFinding/UnityAddon/PlaneFinding.cs
@@ -177,7 +177,7 @@ namespace MixedRealityToolkit.SpatialMapping.SpatialProcessing
         private static readonly List<GCHandle> ReusedPinnedMemoryHandles = new List<GCHandle>();
 
         private static bool findPlanesRunning = false;
-        private static DLLImports.MeshData[] reusedMeshesForMarshalling = null;
+        private static DLLImports.ImportedMeshData[] reusedImportedMeshesForMarshalling = null;
 
         /// <summary>
         /// Validate that no other PlaneFinding API call is currently in progress. As a performance
@@ -240,14 +240,14 @@ namespace MixedRealityToolkit.SpatialMapping.SpatialProcessing
         private static IntPtr PinMeshDataForMarshalling(List<MeshData> meshes)
         {
             // if we have a big enough array reuse it, otherwise create new
-            if (reusedMeshesForMarshalling == null || reusedMeshesForMarshalling.Length < meshes.Count)
+            if (reusedImportedMeshesForMarshalling == null || reusedImportedMeshesForMarshalling.Length < meshes.Count)
             {
-                reusedMeshesForMarshalling = new DLLImports.MeshData[meshes.Count];
+                reusedImportedMeshesForMarshalling = new DLLImports.ImportedMeshData[meshes.Count];
             }
 
             for (int i = 0; i < meshes.Count; ++i)
             {
-                reusedMeshesForMarshalling[i] = new DLLImports.MeshData()
+                reusedImportedMeshesForMarshalling[i] = new DLLImports.ImportedMeshData()
                 {
                     transform = meshes[i].Transform,
                     vertCount = meshes[i].Vertices.Length,
@@ -258,7 +258,7 @@ namespace MixedRealityToolkit.SpatialMapping.SpatialProcessing
                 };
             }
 
-            return PinObject(reusedMeshesForMarshalling);
+            return PinObject(reusedImportedMeshesForMarshalling);
         }
 
         /// <summary>
@@ -291,7 +291,7 @@ namespace MixedRealityToolkit.SpatialMapping.SpatialProcessing
         private class DLLImports
         {
             [StructLayout(LayoutKind.Sequential)]
-            public struct MeshData
+            public struct ImportedMeshData
             {
                 public Matrix4x4 transform;
                 public Int32 vertCount;


### PR DESCRIPTION
Update the plane finding scripts a bit to follow the MRTK coding guidelines, as well as porting over some changes that were checked into the HTK-Unity repo but never brought back here.