### PR TITLE
Update scripts for GPUStats and update version to 1.0.0 (no preview)

### DIFF
--- a/CI/pack.yml
+++ b/CI/pack.yml
@@ -1,19 +1,22 @@
 # [Template] Download DLL artifacts and npm pack
 
 parameters:
-- name: ArtifactName
+- name: DownloadArtifactName
   type: string
-  default: ''
+  default: 'UPMFolder'
+- name: UploadArtifactName
+  type: string
+  default: 'UPMTarball'
 
 steps:
 - task: DownloadBuildArtifacts@0
   displayName: Download built DLLs
   inputs:
-    artifactName: ${{ parameters.ArtifactName }}
+    artifactName: ${{ parameters.DownloadArtifactName }}
     downloadPath: $(Build.SourcesDirectory)
 
 - script: |
-    npm pack $(Build.SourcesDirectory)/${{ parameters.ArtifactName }}
+    npm pack $(Build.SourcesDirectory)/${{ parameters.DownloadArtifactName }}
   displayName: Package for UPM
 
 - task: CopyFiles@2
@@ -25,4 +28,4 @@ steps:
 - task: PublishBuildArtifacts@1
   displayName: Publish UPM artifacts
   inputs:
-    artifactName: UPMTarball
+    artifactName: ${{ parameters.UploadArtifactName }}

--- a/CI/pipeline.yml
+++ b/CI/pipeline.yml
@@ -52,7 +52,7 @@ jobs:
   steps:
   - template: sign.yml
     parameters:
-      ArtifactName: ${{ parameters.ProjectFriendlyName }}
+      DownloadArtifactName: ${{ parameters.ProjectFriendlyName }}
       UnityFolderPath: ${{ parameters.UnityFolderPath }}
       Sign: ${{ parameters.Sign }}
       SignConfigPath: ${{ parameters.SignConfigPath }}
@@ -63,5 +63,3 @@ jobs:
     vmImage: 'windows-2019'
   steps:
   - template: pack.yml
-    parameters:
-      ArtifactName: UPMFolder_${{ parameters.ProjectFriendlyName }}

--- a/CI/sign.yml
+++ b/CI/sign.yml
@@ -1,7 +1,7 @@
 # [Template] Download built DLL artifacts, sign them, copy to UnityFolderPath folder, upload folder as Azure Artifact
 
 parameters:
-- name: ArtifactName
+- name: DownloadArtifactName
   type: string
   default: ''
 - name: UnityFolderPath
@@ -13,6 +13,9 @@ parameters:
 - name: SignConfigPath
   type: string
   default: ''
+- name: UploadArtifactName
+  type: string
+  default: 'UPMFolder'
 
 steps:
 - task: DownloadBuildArtifacts@0
@@ -32,7 +35,7 @@ steps:
   condition: ${{ parameters.Sign }}
   inputs:
     signConfigXml: ${{ parameters.SignConfigPath }}
-    inPathRoot: $(Agent.TempDirectory)/${{ parameters.ArtifactName }}
+    inPathRoot: $(Agent.TempDirectory)/${{ parameters.DownloadArtifactName }}
     outPathRoot: $(Build.SourcesDirectory)/${{ parameters.UnityFolderPath }}/Plugins
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
@@ -41,7 +44,7 @@ steps:
   displayName: Copy DLLs to package directory
   condition: not(${{ parameters.Sign }})
   inputs:
-    sourceFolder: $(Agent.TempDirectory)/${{ parameters.ArtifactName }}
+    sourceFolder: $(Agent.TempDirectory)/${{ parameters.DownloadArtifactName }}
     contents: '**/*.dll'
     targetFolder: ${{ parameters.UnityFolderPath }}/Plugins
 
@@ -49,4 +52,4 @@ steps:
   displayName: Publish UPM folder
   inputs:
     pathToPublish: ${{ parameters.UnityFolderPath }}
-    artifactName: UPMFolder
+    artifactName: ${{ parameters.UploadArtifactName }}

--- a/GpuStats/UnityAddon/GpuDurationResult.cs
+++ b/GpuStats/UnityAddon/GpuDurationResult.cs
@@ -5,8 +5,18 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 {
     public enum GpuDurationResult
     {
+        /// <summary>
+        /// The duration data is valid and usable.
+        /// </summary>
         Valid,
+        /// <summary>
+        /// Something occurred in between BeginSample and EndSample that caused the timestamp counter to become discontinuous or disjoint.
+        /// Examples include unplugging the AC cord on a laptop, overheating, or throttling up/down due to laptop savings events.
+        /// </summary>
         Disjoint,
+        /// <summary>
+        /// The frame event wasn't found.
+        /// </summary>
         NotFound,
     }
 }

--- a/GpuStats/UnityAddon/GpuDurationResult.cs
+++ b/GpuStats/UnityAddon/GpuDurationResult.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.MixedReality.Toolkit.Utilities
+{
+    public enum GpuDurationResult
+    {
+        Valid,
+        Disjoint,
+        NotFound,
+    }
+}

--- a/GpuStats/UnityAddon/GpuDurationResult.cs.meta
+++ b/GpuStats/UnityAddon/GpuDurationResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d6e763ba5ac2fe84ebacebf3502f35c4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/GpuStats/UnityAddon/GpuStats.cs
+++ b/GpuStats/UnityAddon/GpuStats.cs
@@ -17,7 +17,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         private static extern IntPtr GetRenderEventFunc();
 
         [DllImport("GpuStats")]
-        private static extern double GetGpuTime(int eventId);
+        private static extern double GetGpuDuration(int eventId);
 
         [DllImport("GpuStats")]
         private static extern ulong GetVramUse();
@@ -31,26 +31,49 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         private static int nextAvailableEventId = 0;
 
         /// <summary>
-        /// Gets the latest available sample time for the given event.
+        /// Gets the latest available sample duration for the given event.
         /// </summary>
         /// <param name="eventId">Name of the event.</param>
-        /// <returns>Time in milliseconds.</returns>
-        public static double GetTime(string eventId)
+        /// <param name="duration">The sample duration in seconds.</param>
+        /// <returns>Whether the query result is valid, the query was disjoint, or the event ID was not found.</returns>
+        public static GpuDurationResult GetSampleDuration(string eventId, out double duration)
         {
             int eventValue;
             if (EventIds.TryGetValue(eventId, out eventValue))
             {
-                return GetGpuTime(eventValue);
+                var result = GetGpuDuration(eventValue);
+                if (result < -1.0)
+                {
+                    duration = double.NaN;
+                    return GpuDurationResult.NotFound;
+                }
+
+                if (result < 0.0)
+                {
+                    duration = double.NaN;
+                    return GpuDurationResult.Disjoint;
+                }
+
+                duration = result;
+                return GpuDurationResult.Valid;
             }
 
-            return -1;
+            duration = double.NaN;
+            return GpuDurationResult.NotFound;
         }
+
+        /// <summary>
+        /// Gets the latest queried VRAM usage.
+        /// </summary>
+        /// <remarks>Uses DXGI_QUERY_VIDEO_MEMORY_INFO for this data.</remarks>
+        /// <returns>The VRAM usage in bytes.</returns>
+        public static ulong GetVideoMemoryUsage() => GetVramUse();
 
         /// <summary>
         /// Begins sampling GPU time.
         /// </summary>
         /// <param name="eventId">Name of the event.</param>
-        /// <returns>Returns true if a BeginSample with the same event name was last added.</returns>
+        /// <returns>Whether a <see cref="BeginSample"/> with the same event name was added.</returns>
         public static bool BeginSample(string eventId)
         {
             int eventValue;
@@ -67,7 +90,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
             if (CurrentEventId.Contains(eventValue))
             {
-                Debug.LogWarning("BeginSample() is being called without a corresponding EndSample() call.");
+                Debug.LogWarning("BeginSample() is being called again without a corresponding EndSample() call.");
                 return false;
             }
 
@@ -91,10 +114,5 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 GL.IssuePluginEvent(GetRenderEventFunc(), eventId);
             }
         }
-
-        /// <summary>
-        /// Provides the current VRAM usage according to DXGI_QUERY_VIDEO_MEMORY_INFO.
-        /// </summary>
-        public static ulong GetVramUsage() => GetVramUse();
     }
 }

--- a/GpuStats/UnityAddon/GpuTimingCamera.cs
+++ b/GpuStats/UnityAddon/GpuTimingCamera.cs
@@ -2,12 +2,14 @@
 // Licensed under the MIT License.
 
 using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.XR;
 
 namespace Microsoft.MixedReality.Toolkit.Utilities
 {
     /// <summary>
     /// Tracks the GPU time spent rendering a camera.
-    /// For stereo rendering sampling is made from the beginning of the left eye to the end of the right eye.
+    /// For multi-pass stereo rendering, sampling is made from the beginning of the left eye to the end of the right eye.
     /// </summary>
     public class GpuTimingCamera : MonoBehaviour
     {
@@ -16,20 +18,15 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
         private Camera timingCamera;
 
-        private void Awake()
+        protected void Start()
         {
             timingCamera = GetComponent<Camera>();
-            Debug.Assert(timingCamera, "GpuTimingComponent must be attached to a Camera.");
-
-            if (timingCamera == null)
-            {
-                enabled = false;
-            }
+            Debug.Assert(timingCamera, "GpuTimingCamera component must be attached to a Camera");
         }
 
         protected void OnPreRender()
         {
-            if (timingCamera.stereoActiveEye == Camera.MonoOrStereoscopicEye.Left || timingCamera.stereoActiveEye == Camera.MonoOrStereoscopicEye.Mono)
+            if (timingCamera.stereoActiveEye != Camera.MonoOrStereoscopicEye.Right)
             {
                 GpuStats.BeginSample(timingTag);
             }
@@ -37,7 +34,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
         protected void OnPostRender()
         {
-            if (timingCamera.stereoActiveEye == Camera.MonoOrStereoscopicEye.Right || timingCamera.stereoActiveEye == Camera.MonoOrStereoscopicEye.Mono)
+            if (timingCamera.stereoActiveEye != Camera.MonoOrStereoscopicEye.Left
+                || (XRSettings.isDeviceActive
+                    && (XRSettings.eyeTextureDesc.vrUsage == VRTextureUsage.TwoEyes
+                        || XRSettings.eyeTextureDesc.dimension == TextureDimension.Tex2DArray)))
             {
                 GpuStats.EndSample();
             }

--- a/GpuStats/UnityAddon/package.json
+++ b/GpuStats/UnityAddon/package.json
@@ -1,8 +1,8 @@
 {
     "name": "com.microsoft.mixedreality.toolkit.gpustats",
     "displayName": "Mixed Reality Toolkit GPU Stats",
-    "version": "1.0.0-preview.1",
-    "unity": "2019.4",
+    "version": "1.0.0",
+    "unity": "2018.4",
     "description": "Provides utilities for accessing stats about the GPU, like frame timing and VRAM usage.",
     "keywords": [
         "mrtk",


### PR DESCRIPTION
1. Update Unity scripts to match the latest state of the plug-in (corresponds to https://github.com/microsoft/MixedRealityToolkit-Unity/pull/3344, which we didn't end up taking into HTK)
1. Update GPUStats version to 1.0.0 for release, dropping the `-preview`
1. Also lowers the specified Unity version to 2018.4, since we don't have any specific dependencies on 2019.