### PR TITLE
Gpu timing camera event

### DIFF
--- a/GpuStats/UnityAddon/GpuStats.cs
+++ b/GpuStats/UnityAddon/GpuStats.cs
@@ -38,8 +38,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <returns>Whether the query result is valid, the query was disjoint, or the event ID was not found.</returns>
         public static GpuDurationResult GetSampleDuration(string eventId, out double duration)
         {
-            int eventValue;
-            if (EventIds.TryGetValue(eventId, out eventValue))
+            if (EventIds.TryGetValue(eventId, out int eventValue))
             {
                 var result = GetGpuDuration(eventValue);
                 if (result < -1.0)
@@ -76,8 +75,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <returns>Whether a <see cref="BeginSample"/> with the same event name was added.</returns>
         public static bool BeginSample(string eventId)
         {
-            int eventValue;
-            if (!EventIds.TryGetValue(eventId, out eventValue))
+            if (!EventIds.TryGetValue(eventId, out int eventValue))
             {
                 if (nextAvailableEventId == BaseEndEventId)
                 {

--- a/GpuStats/UnityAddon/GpuTimingCamera.cs
+++ b/GpuStats/UnityAddon/GpuTimingCamera.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using UnityEngine;
+using UnityEngine.Events;
 using UnityEngine.Rendering;
 using UnityEngine.XR;
 
@@ -13,8 +15,16 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
     /// </summary>
     public class GpuTimingCamera : MonoBehaviour
     {
-        [SerializeField]
+        [SerializeField, Tooltip("The tag to use with GpuStats.BeginSample.")]
         private string timingTag = "Frame";
+
+        [SerializeField, Tooltip("Fires in OnPreRender with the data from the previous frame.")]
+        private UnityGpuFrameDurationEvent newGpuFrameDuration = null;
+
+        /// <summary>
+        /// Fires in OnPreRender with the data from the previous frame.
+        /// </summary>
+        public UnityGpuFrameDurationEvent NewGpuFrameDuration => newGpuFrameDuration;
 
         private Camera timingCamera;
 
@@ -26,6 +36,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
         protected void OnPreRender()
         {
+            GpuDurationResult durationResult = GpuStats.GetSampleDuration(timingTag, out double duration);
+            newGpuFrameDuration?.Invoke(durationResult, (float)duration);
+
             if (timingCamera.stereoActiveEye != Camera.MonoOrStereoscopicEye.Right)
             {
                 GpuStats.BeginSample(timingTag);
@@ -43,4 +56,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             }
         }
     }
+
+    /// <summary>
+    /// A custom UnityEvent providing a GpuDurationResult and a float duration.
+    /// </summary>
+    [Serializable]
+    public class UnityGpuFrameDurationEvent : UnityEvent<GpuDurationResult, float> { }
 }

--- a/GpuStats/UnityAddon/GpuTimingCamera.cs
+++ b/GpuStats/UnityAddon/GpuTimingCamera.cs
@@ -36,8 +36,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
         protected void OnPreRender()
         {
-            GpuDurationResult durationResult = GpuStats.GetSampleDuration(timingTag, out double duration);
-            newGpuFrameDuration?.Invoke(durationResult, (float)duration);
+            if (newGpuFrameDuration?.GetPersistentEventCount() > 0)
+            {
+                newGpuFrameDuration.Invoke(GpuStats.GetSampleDuration(timingTag, out double duration), (float)duration);
+            }
 
             if (timingCamera.stereoActiveEye != Camera.MonoOrStereoscopicEye.Right)
             {


### PR DESCRIPTION
Re-adds an event from https://github.com/microsoft/MixedRealityToolkit-Unity/pull/3344 that wasn't ported over in #250.