### PR TITLE
switch to vs 2019 compiler

### DIFF
--- a/WinRTTextToSpeech/WinRTTextToSpeech/WinRTTextToSpeech.vcxproj
+++ b/WinRTTextToSpeech/WinRTTextToSpeech/WinRTTextToSpeech.vcxproj
@@ -42,7 +42,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">


### PR DESCRIPTION
this change should enable the pipeline to properly build the winrt text to speech dll