### PR TITLE
enable filtering of target platforms during ci

### DIFF
--- a/CI/Templates/pipeline.yml
+++ b/CI/Templates/pipeline.yml
@@ -11,6 +11,9 @@ parameters:
 - name: UnityFolderPath
   type: string
   default: ''
+- name: Platforms
+  type: string
+  default: 'x86 x64 ARM ARM64'
 - name: Sign
   type: boolean
   default: false
@@ -24,14 +27,18 @@ jobs:
     vmImage: windows-2019
   strategy:
     matrix:
-      x86:
-        BuildPlatform: x86
-      x64:
-        BuildPlatform: x64
-      ARM:
-        BuildPlatform: ARM
-      ARM64:
-        BuildPlatform: ARM64
+      ${{ if contains(parameters.Platforms, 'x86') }}:
+        x86:
+          BuildPlatform: x86
+      ${{ if contains(parameters.Platforms, 'x64') }}:
+        x64:
+          BuildPlatform: x64
+      ${{ if contains(parameters.Platforms, 'ARM') }}:
+        ARM:
+          BuildPlatform: ARM
+      ${{ if contains(parameters.Platforms, 'ARM64') }}:
+        ARM64:
+          BuildPlatform: ARM64
   steps:
   - template: Tasks/build.yml
     parameters:

--- a/CI/azure-pipelines.yml
+++ b/CI/azure-pipelines.yml
@@ -38,3 +38,4 @@ extends:
       SolutionPath: $(Build.SourcesDirectory)/WinRTTextToSpeech/WinRTTextToSpeech.sln
       BuildOutputPath: $(Build.SourcesDirectory)/WinRTTextToSpeech/Release
       UnityFolderPath: $(Build.SourcesDirectory)/WinRTTextToSpeech/UnityAddon
+      Platforms: 'x86 x64'


### PR DESCRIPTION
this change makes it possible to configure the pipeline scripts (yml) to specify the desired target platforms that will be built. it was needed for the winrttexttospeech plugin as it only needs x86 and x64 builds