### PR TITLE
Add support for custom voice name to windows TTS

### DIFF
--- a/WinRTTextToSpeech/UnityAddon/CHANGELOG.md
+++ b/WinRTTextToSpeech/UnityAddon/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.1
+* Adds support for custom voice name in TrySynthesizePhrase
+
 ## 1.0.0
 
 * Initial release.

--- a/WinRTTextToSpeech/UnityAddon/CHANGELOG.md
+++ b/WinRTTextToSpeech/UnityAddon/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.0.1
-* Adds support for custom voice name in TrySynthesizePhrase
+* Adds TrySynthesizePhraseWithCustomVoice for synthesis with custom voice
 
 ## 1.0.0
 

--- a/WinRTTextToSpeech/UnityAddon/WinRTTextToSpeechPinvokes.cs
+++ b/WinRTTextToSpeech/UnityAddon/WinRTTextToSpeechPinvokes.cs
@@ -18,6 +18,16 @@ namespace Microsoft.MixedReality.Toolkit.Speech.Windows
             CallingConvention = CallingConvention.StdCall)]
         public static extern bool TrySynthesizePhrase(
             string phrase,
+            out IntPtr data,
+            out int length);
+
+        [DllImport(
+            "WinRTTextToSpeech.dll",
+            EntryPoint = "TrySynthesizePhraseWithCustomVoice",
+            CharSet = CharSet.Ansi,
+            CallingConvention = CallingConvention.StdCall)]
+        public static extern bool TrySynthesizePhraseWithCustomVoice(
+            string phrase,
             string voiceName,
             out IntPtr data,
             out int length);

--- a/WinRTTextToSpeech/UnityAddon/WinRTTextToSpeechPinvokes.cs
+++ b/WinRTTextToSpeech/UnityAddon/WinRTTextToSpeechPinvokes.cs
@@ -18,6 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.Speech.Windows
             CallingConvention = CallingConvention.StdCall)]
         public static extern bool TrySynthesizePhrase(
             string phrase,
+            string voiceName,
             out IntPtr data,
             out int length);
 

--- a/WinRTTextToSpeech/UnityAddon/package.json
+++ b/WinRTTextToSpeech/UnityAddon/package.json
@@ -2,7 +2,7 @@
 {
     "name": "com.microsoft.mrtk.tts.windows",
     "displayName": "MRTK Windows Text-to-Speech Plugin",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "unity": "2020.3",
     "msftFeatureCategory": "MRTK3",
     "description": "Enables synthesizing text phrases into audio in standalone Windows projects.",

--- a/WinRTTextToSpeech/WinRTTextToSpeech/WinRTTextToSpeech.cpp
+++ b/WinRTTextToSpeech/WinRTTextToSpeech/WinRTTextToSpeech.cpp
@@ -24,6 +24,7 @@ EXTERN_C
 /// <returns>True if the synthesis is successful, or false.</returns>
 DLLEXPORT bool __stdcall TrySynthesizePhrase(
 	const char* phrase,
+	const char* voiceName,
 	uint8_t** data,
 	uint32_t& dataLength)
 {
@@ -38,6 +39,19 @@ DLLEXPORT bool __stdcall TrySynthesizePhrase(
 			*data = nullptr;
 			dataLength = 0;
 			return false;
+		}
+	}
+	
+	// Search for the input voice name
+	auto voices = synthesizer.AllVoices();
+	for (auto it = begin(voices); it != end(voices); ++it) {
+		std::string displayName = to_string((*it).DisplayName());
+		std::string voiceString = voiceName;
+
+		if (displayName.find(voiceString) != std::string::npos)
+		{
+			synthesizer.Voice(*it);
+			break;
 		}
 	}
 

--- a/WinRTTextToSpeech/WinRTTextToSpeech/WinRTTextToSpeech.cpp
+++ b/WinRTTextToSpeech/WinRTTextToSpeech/WinRTTextToSpeech.cpp
@@ -14,95 +14,109 @@ SpeechSynthesizer synthesizer = nullptr;
 
 EXTERN_C
 {
-
-/// <summary>
-/// Synthesizes the provided text into wave format.
-/// </summary>
-/// <param name="phrase">The phrase to be synthesized.</param>
-/// <param name="data">Will receive the audio data in wave format.</param>
-/// <param name="dataLength">The length of the data being returned.</param>
-/// <returns>True if the synthesis is successful, or false.</returns>
-DLLEXPORT bool __stdcall TrySynthesizePhrase(
-	const char* phrase,
-	const char* voiceName,
-	uint8_t** data,
-	uint32_t& dataLength)
-{
-	// Create the synthesizer on first use.
-	if (!synthesizer)
+	/// <summary>
+	/// Synthesizes the provided text into wave format with a custom voice.
+	/// </summary>
+	/// <param name="phrase">The phrase to be synthesized.</param>
+	/// <param name="voiceName">The name of the voice to use if available</param>
+	/// <param name="data">Will receive the audio data in wave format.</param>
+	/// <param name="dataLength">The length of the data being returned.</param>
+	/// <returns>True if the synthesis is successful, or false.</returns>
+	DLLEXPORT bool __stdcall TrySynthesizePhraseWithCustomVoice(
+		const char* phrase,
+		const char* voiceName,
+		uint8_t** data,
+		uint32_t& dataLength)
 	{
-		synthesizer = Windows::Media::SpeechSynthesis::SpeechSynthesizer();
-
-		// Confirm one was created successfully.
+		// Create the synthesizer on first use.
 		if (!synthesizer)
+		{
+			synthesizer = Windows::Media::SpeechSynthesis::SpeechSynthesizer();
+
+			// Confirm one was created successfully.
+			if (!synthesizer)
+			{
+				*data = nullptr;
+				dataLength = 0;
+				return false;
+			}
+		}
+		
+		// Search for the input voice name
+		auto voices = synthesizer.AllVoices();
+		for (auto it = begin(voices); it != end(voices); ++it) {
+			std::string displayName = to_string((*it).DisplayName());
+			std::string voiceString = voiceName;
+
+			if (displayName.find(voiceString) != std::string::npos)
+			{
+				synthesizer.Voice(*it);
+				break;
+			}
+		}
+
+		// Attempt to synthesize the specified phrase.
+		SpeechSynthesisStream speechStream = synthesizer.SynthesizeTextToStreamAsync(to_hstring(phrase)).get();
+		if (!speechStream)
 		{
 			*data = nullptr;
 			dataLength = 0;
 			return false;
 		}
-	}
-	
-	// Search for the input voice name
-	auto voices = synthesizer.AllVoices();
-	for (auto it = begin(voices); it != end(voices); ++it) {
-		std::string displayName = to_string((*it).DisplayName());
-		std::string voiceString = voiceName;
 
-		if (displayName.find(voiceString) != std::string::npos)
+		dataLength = (uint32_t)speechStream.Size();
+		
+		const Windows::Storage::Streams::IInputStream& inputStream = speechStream.GetInputStreamAt(0);
+		speechStream.Close();
+		if (!inputStream)
 		{
-			synthesizer.Voice(*it);
-			break;
+			*data = nullptr;
+			dataLength = 0;
+			return false;
 		}
-	}
 
-	// Attempt to synthesize the specified phrase.
-	SpeechSynthesisStream speechStream = synthesizer.SynthesizeTextToStreamAsync(to_hstring(phrase)).get();
-	if (!speechStream)
-	{
-		*data = nullptr;
-		dataLength = 0;
-		return false;
-	}
+		Windows::Storage::Streams::DataReader reader = Windows::Storage::Streams::DataReader(inputStream);
+		if (!reader)
+		{
+			inputStream.Close();
+			*data = nullptr;
+			dataLength = 0;
+			return false;
+		}
 
-	dataLength = (uint32_t)speechStream.Size();
-	
-	const Windows::Storage::Streams::IInputStream& inputStream = speechStream.GetInputStreamAt(0);
-	speechStream.Close();
-	if (!inputStream)
-	{
-		*data = nullptr;
-		dataLength = 0;
-		return false;
-	}
+		// Read the syntesized data and pass it back to the caller.
+		reader.LoadAsync(dataLength).get();
+		*data = new uint8_t[dataLength];
+		reader.ReadBytes(array_view<uint8_t>(*data, *data + dataLength));
 
-	Windows::Storage::Streams::DataReader reader = Windows::Storage::Streams::DataReader(inputStream);
-	if (!reader)
-	{
+		reader.Close();
 		inputStream.Close();
-		*data = nullptr;
-		dataLength = 0;
-		return false;
+		
+		return true;
 	}
 
-	// Read the syntesized data and pass it back to the caller.
-	reader.LoadAsync(dataLength).get();
-	*data = new uint8_t[dataLength];
-	reader.ReadBytes(array_view<uint8_t>(*data, *data + dataLength));
+	/// <summary>
+	/// Frees the memory allocated during synthesis.
+	/// </summary>
+	/// <param name="data">Pointer to the data to be freed.</param>
+	DLLEXPORT void __stdcall FreeSynthesizedData(uint8_t* data)
+	{
+		if (!data) { return; }
+		delete[] data;
+	}
 
-	reader.Close();
-	inputStream.Close();
-	
-	return true;
-}
-
-/// <summary>
-/// Frees the memory allocated during synthesis.
-/// </summary>
-/// <param name="data">Pointer to the data to be freed.</param>
-DLLEXPORT void __stdcall FreeSynthesizedData(uint8_t* data)
-{
-	if (!data) { return; }
-	delete[] data;
-}
-
+	/// <summary>
+	/// Synthesizes the provided text into wave format using the default voice.
+	/// </summary>
+	/// <param name="phrase">The phrase to be synthesized.</param>
+	/// <param name="data">Will receive the audio data in wave format.</param>
+	/// <param name="dataLength">The length of the data being returned.</param>
+	/// <returns>True if the synthesis is successful, or false.</returns>
+	DLLEXPORT bool __stdcall TrySynthesizePhrase(
+		const char* phrase,
+		uint8_t** data,
+		uint32_t& dataLength)
+	{
+		return TrySynthesizePhraseWithCustomVoice(phrase, "Default", data, dataLength);
+	}
 }


### PR DESCRIPTION
Paired with https://github.com/microsoft/MixedRealityToolkit-Unity/pull/11458

Adds support for a custom voice name to the windows TTS package. This allows MRTK users to use custom voices with TTS on editor and standalone builds