### PR TITLE
Update the MRTK Windows Text-To-Speech Plugin package to be compatible with Unity's UPM Asset Store.

### DIFF
--- a/WinRTTextToSpeech/UnityAddon/package.json
+++ b/WinRTTextToSpeech/UnityAddon/package.json
@@ -2,10 +2,12 @@
 {
     "name": "com.microsoft.mrtk.tts.windows",
     "displayName": "MRTK Windows Text-to-Speech Plugin",
-    "version": "1.0.1",
-    "unity": "2020.3",
+    "version": "1.0.2",
+    "unity": "2021.3",
+    "unityRelease": "26f1",
     "msftFeatureCategory": "MRTK3",
     "description": "Enables synthesizing text phrases into audio in standalone Windows projects.",
+    "documentationUrl": "https://aka.ms/mrtk3winspeechapi",
     "keywords": [
         "mrtk",
         "microsoft",


### PR DESCRIPTION
## Overview

Updated the MRTK Windows Text-To-Speech Plugin package to be compatible with Unity's UPM Asset Store.

‼️ Note, the min Unity version supporting UPM Asset Store packages is 2021.3.26f1. That's why you see "unityRelease"="26f1". This change won't prohibit people from obtaining the this package via the MR Feature Tool or scoped registries on older versions of the Unity.

* Had to specify unity patch release. The minimum supported version for the UPM Asset Store is 2021.3.26f1, hence this patch number
* Had to specify a documentation URL

## Changes
- Fixes: https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/issues/518