### PR TITLE
Updating CHANGELOG.md to satisfy UMP package publishing requirements

### DIFF
--- a/WinRTTextToSpeech/UnityAddon/CHANGELOG.md
+++ b/WinRTTextToSpeech/UnityAddon/CHANGELOG.md
@@ -1,8 +1,27 @@
 # Changelog
 
-## 1.0.1
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [1.0.3] - 2024-01-18
+
+### Fixed
+
+* Support for UPM package publishing in the Unity Asset Store
+
+## [1.0.2] - 2023-12-01
+
+### Added
+
+* Support for UPM package publishing in the Unity Asset Store
+
+## [1.0.1] - 2023-05-03
+
+### Added
+
 * Adds TrySynthesizePhraseWithCustomVoice for synthesis with custom voice
 
-## 1.0.0
+## [1.0.0] - 2023-12-08
+
+### Added
 
 * Initial release.

--- a/WinRTTextToSpeech/UnityAddon/package.json
+++ b/WinRTTextToSpeech/UnityAddon/package.json
@@ -2,7 +2,7 @@
 {
     "name": "com.microsoft.mrtk.tts.windows",
     "displayName": "MRTK Windows Text-to-Speech Plugin",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "unity": "2021.3",
     "unityRelease": "26f1",
     "msftFeatureCategory": "MRTK3",


### PR DESCRIPTION
In order to publish UMP Packages to the Unity Store, Unity requires that the package's CHANGELOG.md follows the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)  format.  Fixing this, and updating version number. 