### PR TITLE
Updating TTS package to meeting Unity Asset Store requirements

### DIFF
--- a/CI/Templates/Tasks/pack.yml
+++ b/CI/Templates/Tasks/pack.yml
@@ -96,7 +96,7 @@ steps:
   displayName: Copy README to Documents~
   inputs:
     sourceFolder: ${{ parameters.UnityFolderPath }}
-    contents: README.md*
+    contents: README.md
     targetFolder: ${{ parameters.UnityFolderPath }}/Documentation~
 
 - task: DeleteFiles@1

--- a/WinRTTextToSpeech/UnityAddon/CHANGELOG.md
+++ b/WinRTTextToSpeech/UnityAddon/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.0.4] - 2024-01-19
+
+### Fixed
+
+* Support for UPM package publishing in the Unity Asset Store
+  
 ## [1.0.3] - 2024-01-18
 
 ### Fixed

--- a/WinRTTextToSpeech/UnityAddon/README.md.meta
+++ b/WinRTTextToSpeech/UnityAddon/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 814dafb10360836459a03a158385efc9
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/WinRTTextToSpeech/UnityAddon/README.md.meta
+++ b/WinRTTextToSpeech/UnityAddon/README.md.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 814dafb10360836459a03a158385efc9
-TextScriptImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/WinRTTextToSpeech/UnityAddon/package.json
+++ b/WinRTTextToSpeech/UnityAddon/package.json
@@ -2,7 +2,7 @@
 {
     "name": "com.microsoft.mrtk.tts.windows",
     "displayName": "MRTK Windows Text-to-Speech Plugin",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "unity": "2021.3",
     "unityRelease": "26f1",
     "msftFeatureCategory": "MRTK3",


### PR DESCRIPTION
The Unity Asset Store requires that the `Documentation~` not have `.meta` files.  This change avoids copying the README.md.meta file to `the Documentation~` folder.