### PR TITLE
Small change to regex in python file to prevent codeql from flagging …

### DIFF
--- a/Sharing/Src/External/swig/Doc/Manual/makechap.py
+++ b/Sharing/Src/External/swig/Doc/Manual/makechap.py
@@ -72,11 +72,11 @@ name = ""
 
 # Regexs for <h1>,... <h5> sections
 
-h1 = re.compile(r".*?<H1>(<a.*?>\s*[\d\s]*(.*?)</a>)*[\d\s]*(.*?)</H1>", re.IGNORECASE)
-h2 = re.compile(r".*?<H2>(<a.*?>\s*[\d\.\s]*(.*?)</a>)*[\d\.\s]*(.*?)</H2>", re.IGNORECASE)
-h3 = re.compile(r".*?<H3>(<a.*?>\s*[\d\.\s]*(.*?)</a>)*[\d\.\s]*(.*?)</H3>", re.IGNORECASE)
-h4 = re.compile(r".*?<H4>(<a.*?>\s*[\d\.\s]*(.*?)</a>)*[\d\.\s]*(.*?)</H4>", re.IGNORECASE)
-h5 = re.compile(r".*?<H5>(<a.*?>\s*[\d\.\s]*(.*?)</a>)*[\d\.\s]*(.*?)</H5>", re.IGNORECASE)
+h1 = re.compile(r"^.*?<H1>(<a[^>]*>\s*[\d\s]*[^<]*</a>)*[\d\s]*[^<]*</H1>$", re.IGNORECASE)
+h2 = re.compile(r"^.*?<H2>(<a[^>]*>\s*[\d\s]*[^<]*</a>)*[\d\s]*[^<]*</H2>$", re.IGNORECASE)
+h3 = re.compile(r"^.*?<H3>(<a[^>]*>\s*[\d\s]*[^<]*</a>)*[\d\s]*[^<]*</H3>$", re.IGNORECASE)
+h4 = re.compile(r"^.*?<H4>(<a[^>]*>\s*[\d\s]*[^<]*</a>)*[\d\s]*[^<]*</H4>$", re.IGNORECASE)
+h5 = re.compile(r"^.*?<H5>(<a[^>]*>\s*[\d\s]*[^<]*</a>)*[\d\s]*[^<]*</H5>$", re.IGNORECASE)
 
 data = open(filename).read()            # Read data
 open(filename+".bak","w").write(data)   # Make backup


### PR DESCRIPTION
…it for exponential backtracking

^ and $ are added to anchor the pattern to the start and end of the string, respectively.
<a[^>]*> ensures that the <a> tag is matched without ambiguity by excluding the > character inside the tag.
[^<]* ensures that the content inside the tags does not include <, which helps avoid nested tags and reduces ambiguity.
The revised pattern is more deterministic and avoids the ambiguous repetition that can lead to exponential backtracking.

This python script is only used when creating the documentation for SWIG, no impact to any build.