### PR TITLE
Fix for Microphone Streaming Inconsistencies (Booleans/Error Codes for Initialisation, Starting Streams and Recording)

### DIFF
--- a/Input/MicStreamSelector/Source/MicStreamSelector.cpp
+++ b/Input/MicStreamSelector/Source/MicStreamSelector.cpp
@@ -47,9 +47,12 @@ static  char                    filepath_char[MAX_PATH];        // stores the fu
 static  std::queue<Windows::Media::AudioFrame^> audioqueue;     // stores our microphone data to hand back to the app
 
 // error codes to hand back to engine with nice printed output
-private enum ErrorCodes { ALREADY_RUNNING = -10, NO_AUDIO_DEVICE, NO_INPUT_DEVICE, ALREADY_RECORDING, GRAPH_NOT_EXIST, CHANNEL_COUNT_MISMATCH, FILE_CREATION_PERMISSION_ERROR, NOT_ENOUGH_DATA, NEED_ENABLED_MIC_CAPABILITY };
+private enum ErrorCodes { ALREADY_PAUSED = -15, ALREADY_RESUMED = -14, ALREADY_STREAMING = -13, NOT_STREAMING = -12, NOT_RUNNING = -11, ALREADY_RUNNING = -10, NO_AUDIO_DEVICE, NO_INPUT_DEVICE, ALREADY_RECORDING, GRAPH_NOT_EXIST, CHANNEL_COUNT_MISMATCH, FILE_CREATION_PERMISSION_ERROR, NOT_ENOUGH_DATA, NEED_ENABLED_MIC_CAPABILITY };
 
+bool    initialized;
 bool    recording;
+bool    streaming;
+bool    paused;
 int     appExpectedBufferLength;
 int     dataInBuffer;
 int     samplesPerQuantum;  // preferred sample size per chunk of data from the audio driver. usually you want system default.
@@ -57,7 +60,10 @@ int     numChannels;
 int     indexInFrame;       // keeps track of copying data out of the plug-in and into the application
 
 void resetToDefaults() {    // used on init to reset state of the plug-in
+    initialized = false;
     recording = false;
+    streaming = false;
+    paused = false;
     appExpectedBufferLength = -1; // By making negative, we won't output data until we get at least one app call.
     dataInBuffer = 0;
     samplesPerQuantum = 256;
@@ -204,6 +210,8 @@ extern "C"
         // Make a callback at the end of every frame to store our data until the app wants it.
         graph->QuantumProcessed += ref new Windows::Foundation::TypedEventHandler<Windows::Media::Audio::AudioGraph ^, Platform::Object ^>(&OnQuantumProcessed);
 
+        initialized = true;
+
         return 0;
     }
 
@@ -224,6 +232,10 @@ extern "C"
 
     API int MicStartStream(bool keepData, bool previewOnDevice, CallbackIntoHost cb)
     {
+        if (streaming)
+        {
+            return ErrorCodes::ALREADY_STREAMING;
+        }
         if (!graph)
         {
             int err = MicInitializeDefault(0);
@@ -243,17 +255,23 @@ extern "C"
         }
         hostCallback = cb;
         graph->Start();
+        streaming = true;
         return 0;
     }
 
     API int MicStopStream()
     {
+        if (!streaming)
+        {
+            return ErrorCodes::NOT_STREAMING;
+        }
         if (!graph)
         {
             return ErrorCodes::GRAPH_NOT_EXIST;
         }
         graph->Stop();
         hostCallback = nullptr;
+        streaming = false;
         return 0;
     }
 
@@ -384,20 +402,30 @@ extern "C"
     }
 
     API int MicPause() {
+        if (paused)
+        {
+            return ErrorCodes::ALREADY_PAUSED;
+        }
         if (!graph)
         {
             return ErrorCodes::GRAPH_NOT_EXIST;
         }
         graph->Stop();
+        paused = true;
         return 0;
     }
 
     API int MicResume() {
+        if (!paused)
+        {
+            return ErrorCodes::ALREADY_RESUMED;
+        }
         if (!graph)
         {
             return ErrorCodes::GRAPH_NOT_EXIST;
         }
         graph->Start();
+        paused = false;
         return 0;
     }
 
@@ -415,6 +443,10 @@ extern "C"
 
     API int MicDestroy()
     {
+        if (!initialized)
+        {
+            return ErrorCodes::NOT_RUNNING;
+        }
         if (!graph) // If there isn't a graph, there is nothing to stop, so just return
         {
             return ErrorCodes::GRAPH_NOT_EXIST;
@@ -443,6 +475,7 @@ extern "C"
 #ifdef MEMORYLEAKDETECT
         _CrtDumpMemoryLeaks(); // output our memory stats if desired
 #endif // MEMORYLEAKDETECT
+        initialized = false;
         return 0;
     }
 

--- a/Input/MicStreamSelector/UnityAddon/WindowsMicrophoneStream.cs
+++ b/Input/MicStreamSelector/UnityAddon/WindowsMicrophoneStream.cs
@@ -102,7 +102,9 @@ namespace Microsoft.MixedReality.Toolkit.Audio
                 return WindowsMicrophoneStreamErrorCode.Success;
             }
 
-           return (WindowsMicrophoneStreamErrorCode)MicInitializeCustomRate((int)streamType, AudioSettings.outputSampleRate);
+            initialized = true;
+
+            return (WindowsMicrophoneStreamErrorCode)MicInitializeCustomRate((int)streamType, AudioSettings.outputSampleRate);
         }
 
         private bool paused = false;
@@ -121,6 +123,8 @@ namespace Microsoft.MixedReality.Toolkit.Audio
                 // The microphone stream is already paused, no need to alarm the calling code.
                 return WindowsMicrophoneStreamErrorCode.Success;
             }
+
+            paused = true;
 
             return (WindowsMicrophoneStreamErrorCode)MicPause();
         }
@@ -154,6 +158,8 @@ namespace Microsoft.MixedReality.Toolkit.Audio
                 return WindowsMicrophoneStreamErrorCode.Success;
             }
 
+            paused = false;
+
             return (WindowsMicrophoneStreamErrorCode)MicResume();
         }
 
@@ -181,6 +187,8 @@ namespace Microsoft.MixedReality.Toolkit.Audio
                 // The microphone stream is already recording, no need to alarm the calling code.
                 return WindowsMicrophoneStreamErrorCode.Success;
             }
+
+            recording = true;
 
             return (WindowsMicrophoneStreamErrorCode)MicStartRecording(fileName, preview);
         }
@@ -214,6 +222,8 @@ namespace Microsoft.MixedReality.Toolkit.Audio
                 // The microphone stream is already streaming, no need to alarm the calling code.
                 return WindowsMicrophoneStreamErrorCode.Success;
             }
+
+            streaming = true;
 
             return (WindowsMicrophoneStreamErrorCode)MicStartStream(keepData, preview);
         }
@@ -252,6 +262,8 @@ namespace Microsoft.MixedReality.Toolkit.Audio
                 return WindowsMicrophoneStreamErrorCode.Success;
             }
 
+            streaming = false;
+
             return (WindowsMicrophoneStreamErrorCode)MicStopStream();
         }
 
@@ -269,6 +281,8 @@ namespace Microsoft.MixedReality.Toolkit.Audio
                 // The microphone stream is not initialized, no need to alarm the calling code.
                 return WindowsMicrophoneStreamErrorCode.Success;
             }
+
+            initialized = false;
 
             return (WindowsMicrophoneStreamErrorCode)MicDestroy();
         }

--- a/Input/MicStreamSelector/UnityAddon/WindowsMicrophoneStream.cs
+++ b/Input/MicStreamSelector/UnityAddon/WindowsMicrophoneStream.cs
@@ -99,7 +99,7 @@ namespace Microsoft.MixedReality.Toolkit.Audio
             if (initialized)
             {
                 // The microphone stream is already initialized, no need to alarm the calling code.
-                return WindowsMicrophoneStreamErrorCode.Success;
+                return WindowsMicrophoneStreamErrorCode.AlreadyRunning;
             }
 
             initialized = true;
@@ -185,7 +185,7 @@ namespace Microsoft.MixedReality.Toolkit.Audio
             if (recording)
             {
                 // The microphone stream is already recording, no need to alarm the calling code.
-                return WindowsMicrophoneStreamErrorCode.Success;
+                return WindowsMicrophoneStreamErrorCode.AlreadyRecording;
             }
 
             recording = true;

--- a/Input/MicStreamSelector/UnityAddon/WindowsMicrophoneStream.cs
+++ b/Input/MicStreamSelector/UnityAddon/WindowsMicrophoneStream.cs
@@ -91,14 +91,14 @@ namespace Microsoft.MixedReality.Toolkit.Audio
         /// Initializes the microphone stream.
         /// </summary>
         /// <returns>
-        /// A <see cref="WindowsMicrophoneStreamErrorCode"/> value indicating success or the
-        /// reason that the call failed.
+        /// A <see cref="WindowsMicrophoneStreamErrorCode"/> value indicating success, the
+        /// reason that the call failed or the reason why the method did not continue past
+        /// the if-statement check.
         /// </returns>
         public WindowsMicrophoneStreamErrorCode Initialize(WindowsMicrophoneStreamType streamType)
         {
             if (initialized)
             {
-                // The microphone stream is already initialized, no need to alarm the calling code.
                 return WindowsMicrophoneStreamErrorCode.AlreadyRunning;
             }
 
@@ -113,14 +113,14 @@ namespace Microsoft.MixedReality.Toolkit.Audio
         /// Pauses the microphone stream.
         /// </summary>
         /// <returns>
-        /// A <see cref="WindowsMicrophoneStreamErrorCode"/> value indicating success or the
-        /// reason that the call failed.
+        /// A <see cref="WindowsMicrophoneStreamErrorCode"/> value indicating success, the
+        /// reason that the call failed or the reason why the method did not continue past
+        /// the if-statement check.
         /// </returns>
         public WindowsMicrophoneStreamErrorCode Pause()
         {
             if (paused)
             {
-                // The microphone stream is already paused, no need to alarm the calling code.
                 return WindowsMicrophoneStreamErrorCode.AlreadyPaused;
             }
 
@@ -135,8 +135,9 @@ namespace Microsoft.MixedReality.Toolkit.Audio
         /// <param name="buffer"/>The buffer in which to plce the data.</param>
         /// <param name="numChannels">The number of audio channels to read.</param>
         /// <returns>
-        /// A <see cref="WindowsMicrophoneStreamErrorCode"/> value indicating success or the
-        /// reason that the call failed.
+        /// A <see cref="WindowsMicrophoneStreamErrorCode"/> value indicating success, the
+        /// reason that the call failed or the reason why the method did not continue past
+        /// the if-statement check.
         /// </returns>
         public WindowsMicrophoneStreamErrorCode ReadAudioFrame(float[] buffer, int numChannels)
         {
@@ -147,14 +148,14 @@ namespace Microsoft.MixedReality.Toolkit.Audio
         /// Resumes the microphone stream
         /// </summary>
         /// <returns>
-        /// A <see cref="WindowsMicrophoneStreamErrorCode"/> value indicating success or the
-        /// reason that the call failed.
+        /// A <see cref="WindowsMicrophoneStreamErrorCode"/> value indicating success, the
+        /// reason that the call failed or the reason why the method did not continue past
+        /// the if-statement check.
         /// </returns>
         public WindowsMicrophoneStreamErrorCode Resume()
         {
             if (!paused)
             {
-                // The microphone stream is already resumed, no need to alarm the calling code.
                 return WindowsMicrophoneStreamErrorCode.AlreadyResumed;
             }
 
@@ -174,8 +175,9 @@ namespace Microsoft.MixedReality.Toolkit.Audio
         /// audio device.
         /// </param>
         /// <returns>
-        /// A <see cref="WindowsMicrophoneStreamErrorCode"/> value indicating success or the
-        /// reason that the call failed.
+        /// A <see cref="WindowsMicrophoneStreamErrorCode"/> value indicating success, the
+        /// reason that the call failed or the reason why the method did not continue past
+        /// the if-statement check.
         /// </returns>
         /// <remarks>
         /// Files are created in the Music Library folder.
@@ -184,7 +186,6 @@ namespace Microsoft.MixedReality.Toolkit.Audio
         {
             if (recording)
             {
-                // The microphone stream is already recording, no need to alarm the calling code.
                 return WindowsMicrophoneStreamErrorCode.AlreadyRecording;
             }
 
@@ -207,8 +208,9 @@ namespace Microsoft.MixedReality.Toolkit.Audio
         /// audio device.
         /// </param>
         /// <returns>
-        /// A <see cref="WindowsMicrophoneStreamErrorCode"/> value indicating success or the
-        /// reason that the call failed.
+        /// A <see cref="WindowsMicrophoneStreamErrorCode"/> value indicating success, the
+        /// reason that the call failed or the reason why the method did not continue past
+        /// the if-statement check.
         /// </returns>
         /// <remarks>
         /// When keepData is set to false, the application will always receive the latest
@@ -219,7 +221,6 @@ namespace Microsoft.MixedReality.Toolkit.Audio
         {
             if (streaming)
             {
-                // The microphone stream is already streaming, no need to alarm the calling code.
                 return WindowsMicrophoneStreamErrorCode.AlreadyStreaming;
             }
 
@@ -251,14 +252,14 @@ namespace Microsoft.MixedReality.Toolkit.Audio
         /// Stops the microphone stream.
         /// </summary>
         /// <returns>
-        /// A <see cref="WindowsMicrophoneStreamErrorCode"/> value indicating success or the
-        /// reason that the call failed.
+        /// A <see cref="WindowsMicrophoneStreamErrorCode"/> value indicating success, the
+        /// reason that the call failed or the reason why the method did not continue past
+        /// the if-statement check.
         /// </returns>
         public WindowsMicrophoneStreamErrorCode StopStream()
         {
             if (!streaming)
             {
-                // The microphone stream is already stopped, no need to alarm the calling code.
                 return WindowsMicrophoneStreamErrorCode.NotStreaming;
             }
 
@@ -271,14 +272,14 @@ namespace Microsoft.MixedReality.Toolkit.Audio
         /// Uninitializes the microphone stream.
         /// </summary>
         /// <returns>
-        /// A <see cref="WindowsMicrophoneStreamErrorCode"/> value indicating success or the
-        /// reason that the call failed.
+        /// A <see cref="WindowsMicrophoneStreamErrorCode"/> value indicating success, the
+        /// reason that the call failed or the reason why the method did not continue past
+        /// the if-statement check.
         /// </returns>
         public WindowsMicrophoneStreamErrorCode Uninitialize()
         {
             if (!initialized)
             {
-                // The microphone stream is not initialized, no need to alarm the calling code.
                 return WindowsMicrophoneStreamErrorCode.NotRunning;
             }
 

--- a/Input/MicStreamSelector/UnityAddon/WindowsMicrophoneStream.cs
+++ b/Input/MicStreamSelector/UnityAddon/WindowsMicrophoneStream.cs
@@ -121,7 +121,7 @@ namespace Microsoft.MixedReality.Toolkit.Audio
             if (paused)
             {
                 // The microphone stream is already paused, no need to alarm the calling code.
-                return WindowsMicrophoneStreamErrorCode.Success;
+                return WindowsMicrophoneStreamErrorCode.AlreadyPaused;
             }
 
             paused = true;
@@ -155,7 +155,7 @@ namespace Microsoft.MixedReality.Toolkit.Audio
             if (!paused)
             {
                 // The microphone stream is already resumed, no need to alarm the calling code.
-                return WindowsMicrophoneStreamErrorCode.Success;
+                return WindowsMicrophoneStreamErrorCode.AlreadyResumed;
             }
 
             paused = false;
@@ -220,7 +220,7 @@ namespace Microsoft.MixedReality.Toolkit.Audio
             if (streaming)
             {
                 // The microphone stream is already streaming, no need to alarm the calling code.
-                return WindowsMicrophoneStreamErrorCode.Success;
+                return WindowsMicrophoneStreamErrorCode.NotStreaming;
             }
 
             streaming = true;
@@ -259,7 +259,7 @@ namespace Microsoft.MixedReality.Toolkit.Audio
             if (!streaming)
             {
                 // The microphone stream is already stopped, no need to alarm the calling code.
-                return WindowsMicrophoneStreamErrorCode.Success;
+                return WindowsMicrophoneStreamErrorCode.AlreadyStoppedStream;
             }
 
             streaming = false;
@@ -279,7 +279,7 @@ namespace Microsoft.MixedReality.Toolkit.Audio
             if (!initialized)
             {
                 // The microphone stream is not initialized, no need to alarm the calling code.
-                return WindowsMicrophoneStreamErrorCode.Success;
+                return WindowsMicrophoneStreamErrorCode.NotRunning;
             }
 
             initialized = false;

--- a/Input/MicStreamSelector/UnityAddon/WindowsMicrophoneStream.cs
+++ b/Input/MicStreamSelector/UnityAddon/WindowsMicrophoneStream.cs
@@ -220,7 +220,7 @@ namespace Microsoft.MixedReality.Toolkit.Audio
             if (streaming)
             {
                 // The microphone stream is already streaming, no need to alarm the calling code.
-                return WindowsMicrophoneStreamErrorCode.NotStreaming;
+                return WindowsMicrophoneStreamErrorCode.AlreadyStreaming;
             }
 
             streaming = true;
@@ -259,7 +259,7 @@ namespace Microsoft.MixedReality.Toolkit.Audio
             if (!streaming)
             {
                 // The microphone stream is already stopped, no need to alarm the calling code.
-                return WindowsMicrophoneStreamErrorCode.AlreadyStoppedStream;
+                return WindowsMicrophoneStreamErrorCode.NotStreaming;
             }
 
             streaming = false;

--- a/Input/MicStreamSelector/UnityAddon/WindowsMicrophoneStreamErrorCodes.cs
+++ b/Input/MicStreamSelector/UnityAddon/WindowsMicrophoneStreamErrorCodes.cs
@@ -14,6 +14,31 @@ namespace Microsoft.MixedReality.Toolkit.Audio
         Success = 0,
 
         /// <summary>
+        /// The microphone stream has already been paused.
+        /// </summary>
+        AlreadyPaused = -15,
+
+        /// <summary>
+        /// The microphone stream has already been resumed.
+        /// </summary>
+        AlreadyResumed = -14,
+
+        /// <summary>
+        /// The microphone stream has already been started.
+        /// </summary>
+        AlreadyStreaming = -13,
+
+        /// <summary>
+        /// The microphone stream has already been stopped.
+        /// </summary>
+        NotStreaming = -12,
+
+        /// <summary>
+        /// The microphone is already uninitialized.
+        /// </summary>
+        NotRunning = -11,
+
+        /// <summary>
         /// The microphone has already been initialized.
         /// </summary>
         AlreadyRunning = -10,


### PR DESCRIPTION
## Overview
When using the MRTK2 Examples, specifically the Audio Demo related to the **_Windows Microphone Stream_** system, there would be issues when trying to switch the state of the microphone. A modification of the demo was made to initialise the stream using the Room stream type, record thirty seconds of audio, uninitialise it and then reinitialise it with the High Quality Voice stream type. However, the state of the microphone, whether it was initialised, recording or streaming, would never change and would just skip over the checks to see if they were still running or not. This would cause some errors where it would believe it hadn't started streaming or been initialised, and made it so attempting to switch between stream types would fail as it had never been uninitialised, or recordings would never start.

This addresses those issues and adds more error codes to both the scripts and plugin files to make it easier to spot issues. The reasoning being that the `SUCCESS` code, where correct as it is working, isn't too descriptive and could possibly lead to 

## Changes
- Added lines to set state Booleans [[d40a22a]](https://github.com/microsoft/MixedRealityToolkit/commit/d40a22a0b5fe61ccbbdabba9db583e81ccef1630)
- Changed the return type of methods to better reflect current stream state [[31f3323]](https://github.com/microsoft/MixedRealityToolkit/commit/31f3323b65410da66ee37122f0497ba82e3cb101)
- Added new stream error codes [[319f2b6]](https://github.com/microsoft/MixedRealityToolkit/commit/319f2b60e19bf243625522b0e0e8d8c8bb6f97de)